### PR TITLE
fix: fix sequential executor bug

### DIFF
--- a/crates/pe/src/executor.rs
+++ b/crates/pe/src/executor.rs
@@ -23,7 +23,8 @@ use metis_vm::ExtCompileWorker;
 #[cfg(feature = "compiler")]
 use revm::ExecuteEvm;
 use revm::{
-    context::{TxEnv, result::InvalidTransaction},
+    DatabaseCommit,
+    context::{ContextTr, TxEnv, result::InvalidTransaction},
     database::CacheDB,
 };
 
@@ -444,6 +445,8 @@ pub fn execute_sequential<DB: DatabaseRef>(
             evm.transact(tx)
                 .map_err(|err| ExecutionError::Custom(err.to_string()))?
         };
+
+        evm.db().commit(result_and_state.state.clone());
 
         let mut execution_result = TxExecutionResult::from_raw(tx_type, result_and_state);
 


### PR DESCRIPTION
In the sequential execution, transaction state was not committed to the database after execution, which caused transactions to be executed without reflecting the results of preceding transactions. This PR fixes that bug.
fix #87 