### PR TITLE
chore: increase stack size to 10MB on windows

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,15 @@
+# Reference: https://github.com/paradigmxyz/reth/blob/main/.cargo/config.toml
+
+[target.x86_64-pc-windows-msvc]
+rustflags = [
+    # Increases the stack size to 10MB, which is
+    # in line with Linux (whereas default for Windows is 1MB)
+    "-Clink-arg=/STACK:10000000",
+]
+
+[target.i686-pc-windows-msvc]
+rustflags = [
+    # Increases the stack size to 10MB, which is
+    # in line with Linux (whereas default for Windows is 1MB)
+    "-Clink-arg=/STACK:10000000",
+]


### PR DESCRIPTION
- chore: increase stack size to 10MB on windows