### PR TITLE
feat: add asm-keccak feature in the chain and pe crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6569,6 +6569,7 @@ dependencies = [
  "reth-evm-ethereum",
  "reth-exex-test-utils",
  "reth-node-api",
+ "reth-node-core",
  "reth-node-ethereum",
  "reth-primitives",
  "reth-primitives-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ reth-node-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v1.3.1
 reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", tag = "v1.3.10" }
 reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.3.10" }
 reth-node-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.3.10" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", tag = "v1.3.10" }
 
 # Allocators
 tikv-jemallocator = "0.6.0"

--- a/crates/chain/Cargo.toml
+++ b/crates/chain/Cargo.toml
@@ -32,6 +32,7 @@ reth-chain-state = {workspace = true, features = ["test-utils"]}
 reth-primitives-traits.workspace = true
 reth-ethereum-primitives.workspace = true
 reth-node-api.workspace = true
+reth-node-core.workspace = true
 
 tokio.workspace = true
 serde.workspace = true
@@ -71,3 +72,9 @@ jemalloc = ["reth/jemalloc", "metis-pe/jemalloc"]
 optimism = ["metis-pe/optimism"]
 compiler = ["metis-pe/compiler", "dep:revmc-build"]
 inference = ["dep:alith"]
+asm-keccak = [
+    "reth-node-core/asm-keccak",
+    "reth-primitives/asm-keccak",
+    "alloy-primitives/asm-keccak",
+    "metis-pe/asm-keccak",
+]

--- a/crates/pe/Cargo.toml
+++ b/crates/pe/Cargo.toml
@@ -12,6 +12,11 @@ optimism = [
 ]
 compiler = ["metis-vm/compiler", "dep:revmc-build"]
 jemalloc = ["dep:tikv-jemallocator"]
+asm-keccak = [
+    "reth-primitives/asm-keccak",
+    "alloy-primitives/asm-keccak",
+    "revm/asm-keccak",
+]
 
 [dependencies]
 metis-primitives.workspace = true

--- a/crates/pe/benches/README.md
+++ b/crates/pe/benches/README.md
@@ -17,3 +17,9 @@ Run the benchmark with the jemalloc and compiler feature:
 ```shell
 JEMALLOC_SYS_WITH_MALLOC_CONF="thp:always,metadata_thp:always" cargo bench --features jemalloc --features compiler --bench gigagas 
 ```
+
+Run the benchmark with the asm-keccak, jemalloc and compiler feature:
+
+```shell
+JEMALLOC_SYS_WITH_MALLOC_CONF="thp:always,metadata_thp:always" cargo bench --features asm-keccak --features jemalloc --features compiler --bench gigagas 
+```


### PR DESCRIPTION
feat: add asm-keccak feature in the chain crate

We need to set up asm related features in the chain crate, because it is related to the performance of the encryption algorithm.

closes #111 
