### PR TITLE
fix: parallel executor nonce check

### DIFF
--- a/crates/pe/tests/raw_transfers.rs
+++ b/crates/pe/tests/raw_transfers.rs
@@ -7,9 +7,8 @@ use revm::primitives::{Address, U256, alloy_primitives::U160};
 
 pub mod common;
 
-// #[test]
-// TODO: https://github.com/MetisProtocol/metis-sdk/issues/128
-fn _repeat_raw_transfer_same_address() {
+#[test]
+fn repeat_raw_transfer_same_address() {
     let block_size = 10; // number of transactions
     common::test_execute(
         // Mock the beneficiary account (`Address:ZERO`) and the next `block_size` user accounts.
@@ -18,8 +17,8 @@ fn _repeat_raw_transfer_same_address() {
             Default::default(),
             Default::default(),
         ),
-        (1..=block_size)
-            .map(|_| {
+        vec![
+            {
                 let caller = Address::from(U160::from(1));
                 let to = Address::from(U160::from(2));
                 TxEnv {
@@ -31,8 +30,9 @@ fn _repeat_raw_transfer_same_address() {
                     nonce: 1,
                     ..TxEnv::default()
                 }
-            })
-            .collect(),
+            };
+            block_size
+        ],
     );
 }
 

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -11,7 +11,9 @@ pub use revm::bytecode::{
     eof::{CodeInfo as EofCodeInfo, EOF_MAGIC_BYTES, EOF_MAGIC_HASH, Eof, EofBody},
     opcode::{OpCode, OpCodeInfo},
 };
-pub use revm::context::{Block, BlockEnv, CfgEnv, ContextTr, TransactTo, Transaction, TxEnv};
+pub use revm::context::{
+    Block, BlockEnv, CfgEnv, ContextTr, TransactTo, Transaction, TxEnv, result::EVMError,
+};
 pub use revm::context_interface::{
     block::{BlobExcessGasAndPrice, calc_blob_gasprice, calc_excess_blob_gas},
     cfg::Cfg,


### PR DESCRIPTION
fix: parallel executor nonce check
test: crates/pe/tests/raw_transfers.rs

For nonce too low error, only block the preceding transactions and cannot make the nonce of the account the same as tx.nonce, so we need to return an error.

fix #128