### PR TITLE
refactor: use moka sync cache for the compiler cache instead of Arc<RwLock<LruCache<K, V>>>

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6371,15 +6371,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lru"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f8cc7106155f10bdf99a6f379688f543ad6596a415375b36a59a054ceda1198"
-dependencies = [
- "hashbrown 0.15.3",
-]
-
-[[package]]
 name = "lz4_flex"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6775,8 +6766,8 @@ dependencies = [
  "alloy-sol-types",
  "anyhow",
  "libloading",
- "lru 0.14.0",
  "metis-primitives",
+ "moka",
  "revm",
  "revmc",
  "revmc-build",

--- a/crates/vm/Cargo.toml
+++ b/crates/vm/Cargo.toml
@@ -16,10 +16,10 @@ revmc = { git = "https://github.com/paradigmxyz/revmc", features = [
 ], optional = true }
 smallvec = "1.14.0"
 libloading = "0.8.6"
-lru = "0.14.0"
 alith = { git = "https://github.com/0xLazAI/alith", tag = "v0.5.1", features = [
     "llamacpp",
 ], optional = true }
+moka = { version = "0.12.10", features = ["sync"] }
 
 [build-dependencies]
 revmc-build = { git = "https://github.com/paradigmxyz/revmc", optional = true }


### PR DESCRIPTION
refactor: use moka sync cache for the compiler cache instead of Arc<RwLock<LruCache<K, V>>> to improve performance through finer grained locks, inspired by https://github.com/paradigmxyz/reth/pull/12214, https://github.com/paradigmxyz/reth/pull/15928 etc.