### PR TITLE
feat: add app cmd with options and settings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1796,6 +1796,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arraydeque"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1873,6 +1879,23 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.101",
+]
+
+[[package]]
+name = "async-tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3609af4bbf701ddaf1f6bb4e6257dff4ff8932327d0e685d3f653724c258b1ac"
+dependencies = [
+ "futures-io",
+ "futures-util",
+ "log",
+ "pin-project-lite",
+ "rustls-native-certs 0.7.3",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.25.0",
+ "tungstenite 0.21.0",
 ]
 
 [[package]]
@@ -2053,7 +2076,7 @@ dependencies = [
  "bitflags 2.9.1",
  "cexpr",
  "clang-sys",
- "itertools 0.11.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -2829,6 +2852,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "config"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "595aae20e65c3be792d05818e8c63025294ac3cb7e200f11459063a352a6ef80"
+dependencies = [
+ "async-trait",
+ "convert_case 0.6.0",
+ "json5",
+ "pathdiff",
+ "ron",
+ "rust-ini",
+ "serde",
+ "serde_json",
+ "toml",
+ "winnow",
+ "yaml-rust2",
+]
+
+[[package]]
 name = "console"
 version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2861,6 +2903,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.16",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "const_format"
 version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2885,6 +2947,15 @@ name = "constant_time_eq"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+
+[[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "convert_case"
@@ -3143,6 +3214,16 @@ dependencies = [
  "generic-array",
  "rand_core 0.6.4",
  "typenum",
+]
+
+[[package]]
+name = "crypto-mac"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
+dependencies = [
+ "generic-array",
+ "subtle",
 ]
 
 [[package]]
@@ -3456,7 +3537,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
 dependencies = [
- "convert_case",
+ "convert_case 0.7.1",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -3579,7 +3660,7 @@ dependencies = [
  "enr",
  "fnv",
  "futures",
- "hashlink",
+ "hashlink 0.9.1",
  "hex",
  "hkdf",
  "lazy_static",
@@ -3606,6 +3687,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.101",
+]
+
+[[package]]
+name = "dlv-list"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
 ]
 
 [[package]]
@@ -3890,7 +3980,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4108,6 +4198,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c606d892c9de11507fa0dcffc116434f94e105d0bbdc4e405b61519464c49d7b"
 dependencies = [
+ "eyre",
  "paste",
 ]
 
@@ -4523,6 +4614,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.3",
+]
+
+[[package]]
 name = "hdrhistogram"
 version = "7.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4639,7 +4739,17 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
+]
+
+[[package]]
+name = "hmac"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "126888268dcc288495a26bf004b38c5fdbb31682f992c84ceb046a1f0fe38840"
+dependencies = [
+ "crypto-mac",
+ "digest 0.9.0",
 ]
 
 [[package]]
@@ -4649,6 +4759,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac-drbg"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17ea0a1394df5b6574da6e0c1ade9e78868c9fb0a4e5ef4428e32da4676b85b1"
+dependencies = [
+ "digest 0.9.0",
+ "generic-array",
+ "hmac 0.8.1",
 ]
 
 [[package]]
@@ -4987,7 +5108,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.57.0",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -5516,7 +5637,7 @@ checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5579,7 +5700,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5648,6 +5769,17 @@ checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "json5"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "serde",
 ]
 
 [[package]]
@@ -5993,12 +6125,14 @@ dependencies = [
  "arrayref",
  "base64 0.22.1",
  "digest 0.9.0",
+ "hmac-drbg",
  "libsecp256k1-core",
  "libsecp256k1-gen-ecmult",
  "libsecp256k1-gen-genmult",
  "rand 0.8.5",
  "serde",
  "sha2 0.9.9",
+ "typenum",
 ]
 
 [[package]]
@@ -6490,13 +6624,35 @@ version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-trait",
+ "base64 0.22.1",
  "cid",
+ "config",
+ "dirs 5.0.1",
+ "ecdsa",
+ "libsecp256k1",
+ "metis-app-options",
  "metis-chain",
+ "metis-primitives",
  "metis-storage",
  "metis-vm",
+ "rand_chacha 0.3.1",
  "serde",
+ "serde_json",
+ "serde_with",
  "tendermint",
+ "tendermint-rpc",
  "tokio",
+ "tower-abci",
+ "tracing",
+]
+
+[[package]]
+name = "metis-app-options"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "metis-primitives",
+ "tendermint-rpc",
  "tracing",
 ]
 
@@ -7482,6 +7638,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-multimap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.14.5",
+]
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7569,6 +7735,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+
+[[package]]
+name = "peg"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9928cfca101b36ec5163e70049ee5368a8a1c3c6efc9ca9c5f9cc2f816152477"
+dependencies = [
+ "peg-macros",
+ "peg-runtime",
+]
+
+[[package]]
+name = "peg-macros"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6298ab04c202fa5b5d52ba03269fb7b74550b150323038878fe6c372d8280f71"
+dependencies = [
+ "peg-runtime",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "peg-runtime"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "132dca9b868d927b35b5dd728167b2dee150eb1ad686008fc71ccb298b776fca"
+
+[[package]]
 name = "pem"
 version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7593,6 +7792,40 @@ dependencies = [
  "memchr",
  "thiserror 2.0.12",
  "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d725d9cfd79e87dccc9341a2ef39d1b6f6353d68c4b33c177febbe1a402c97c5"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db7d01726be8ab66ab32f9df467ae8b1148906685bbe75c82d1e65d7f5b3f841"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f9f832470494906d1fca5329f8ab5791cc60beb230c74815dff541cbd2b5ca0"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -8008,7 +8241,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -8118,7 +8351,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8423,7 +8656,8 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls 0.21.12",
- "rustls-pemfile",
+ "rustls-native-certs 0.6.3",
+ "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -8754,7 +8988,7 @@ name = "reth-codecs-derive"
 version = "1.4.8"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
 dependencies = [
- "convert_case",
+ "convert_case 0.7.1",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -9046,7 +9280,7 @@ dependencies = [
  "digest 0.10.7",
  "futures",
  "generic-array",
- "hmac",
+ "hmac 0.12.1",
  "pin-project",
  "rand 0.8.5",
  "reth-network-peers",
@@ -11762,7 +11996,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
  "subtle",
 ]
 
@@ -11856,6 +12090,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ron"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
+dependencies = [
+ "base64 0.21.7",
+ "bitflags 2.9.1",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
 name = "route-recognizer"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11894,6 +12140,17 @@ name = "ruint-macro"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
+
+[[package]]
+name = "rust-ini"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e310ef0e1b6eeb79169a1171daf9abcb87a2e17c03bee2c4bb100b55c75409f"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
+ "trim-in-place",
+]
 
 [[package]]
 name = "rustc-demangle"
@@ -11950,7 +12207,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11963,7 +12220,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11976,6 +12233,20 @@ dependencies = [
  "ring",
  "rustls-webpki 0.101.7",
  "sct",
+]
+
+[[package]]
+name = "rustls"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.8",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -12000,7 +12271,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
+ "schannel",
+ "security-framework 2.11.1",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 2.2.0",
+ "rustls-pki-types",
  "schannel",
  "security-framework 2.11.1",
 ]
@@ -12024,6 +12308,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
  "base64 0.21.7",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -12054,7 +12347,7 @@ dependencies = [
  "security-framework 3.2.0",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12070,6 +12363,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
  "untrusted",
 ]
 
@@ -13080,7 +13384,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix 1.0.7",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13095,9 +13399,11 @@ dependencies = [
  "ed25519-consensus",
  "flex-error",
  "futures",
+ "k256",
  "num-traits",
  "once_cell",
  "prost",
+ "ripemd",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -13109,6 +13415,20 @@ dependencies = [
  "tendermint-proto",
  "time",
  "zeroize",
+]
+
+[[package]]
+name = "tendermint-config"
+version = "0.40.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "069d1791f9b02a596abcd26eb72003b2e9906c6169a60fa82ffc080dd3a43fda"
+dependencies = [
+ "flex-error",
+ "serde",
+ "serde_json",
+ "tendermint",
+ "toml",
+ "url",
 ]
 
 [[package]]
@@ -13124,6 +13444,40 @@ dependencies = [
  "serde_bytes",
  "subtle-encoding",
  "time",
+]
+
+[[package]]
+name = "tendermint-rpc"
+version = "0.40.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35e0569a4b4cc42ff00df5a665be2858a39ff79df4790b176f1cd0e169bc0fc2"
+dependencies = [
+ "async-trait",
+ "async-tungstenite",
+ "bytes",
+ "flex-error",
+ "futures",
+ "getrandom 0.2.16",
+ "peg",
+ "pin-project",
+ "rand 0.8.5",
+ "reqwest 0.11.27",
+ "semver 1.0.26",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "subtle",
+ "subtle-encoding",
+ "tendermint",
+ "tendermint-config",
+ "tendermint-proto",
+ "thiserror 1.0.69",
+ "time",
+ "tokio",
+ "tracing",
+ "url",
+ "uuid",
+ "walkdir",
 ]
 
 [[package]]
@@ -13461,6 +13815,17 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+dependencies = [
+ "rustls 0.22.4",
+ "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
@@ -13493,7 +13858,7 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.2",
- "tungstenite",
+ "tungstenite 0.26.2",
  "webpki-roots 0.26.11",
 ]
 
@@ -13818,6 +14183,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "trim-in-place"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "343e926fc669bc8cde4fa3129ab681c63671bae288b1f1081ceee6d9d37904fc"
+
+[[package]]
 name = "triomphe"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13828,6 +14199,27 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ef1a641ea34f399a848dea702823bbecfb4c486f911735368f1f137cb8257e1"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http 1.3.1",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "rustls 0.22.4",
+ "rustls-pki-types",
+ "sha1",
+ "thiserror 1.0.69",
+ "url",
+ "utf-8",
+]
 
 [[package]]
 name = "tungstenite"
@@ -14399,7 +14791,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -15050,6 +15442,17 @@ dependencies = [
  "log",
  "mac",
  "markup5ever 0.12.1",
+]
+
+[[package]]
+name = "yaml-rust2"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ce2a4ff45552406d02501cea6c18d8a7e50228e7736a872951fe2fe75c91be7"
+dependencies = [
+ "arraydeque",
+ "encoding_rs",
+ "hashlink 0.10.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,8 @@
 [workspace]
-members = ["crates/*"]
+members = [
+  "crates/*",
+  "crates/app/options"
+]
 
 resolver = "2"
 
@@ -32,6 +35,7 @@ metis-pe = { path = "crates/pe" }
 metis-chain = { path = "crates/chain" }
 metis-app = { path = "crates/app" }
 metis-storage = { path = "crates/storage" }
+metis-app-options = { path = "crates/app/options" }
 
 anyhow = "1.0.97"
 
@@ -180,6 +184,7 @@ either = "1.15.0"
 
 # comefbft abci
 tendermint = "*"
+tendermint-rpc = { version = "*", features = ["secp256k1", "http-client", "websocket-client"] }
 async-trait = "0.1.88"
 tower = "0.5.2"
 tower-abci = "*"
@@ -188,6 +193,13 @@ async-stm = "0.5.0"
 # app
 cid = "*"
 num-derive = "*"
+base64 = "0.22.1"
+serde_with = "*"
+config = "*"
+libsecp256k1 = "*"
+rand_chacha = "0.3.0"
+rocksdb = { version = "*", features = ["multi-threaded-cf"] }
+tempfile = "*"
 
 [workspace.package]
 version = "0.2.1"

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -15,10 +15,23 @@ cid.workspace = true
 serde.workspace = true
 tracing.workspace = true
 tokio.workspace = true
+base64.workspace = true
+tendermint-rpc.workspace = true
+tower-abci.workspace = true
+libsecp256k1.workspace = true
+rand_chacha.workspace = true
+serde_json.workspace = true
 
 metis-chain.workspace = true
 metis-storage.workspace = true
 metis-vm.workspace = true
+metis-app-options.workspace = true
+metis-primitives.workspace = true
+
+serde_with.workspace = true
+config.workspace = true
+dirs = "5.0.1"
+ecdsa = "0.16.9"
 
 [lints]
 workspace = true

--- a/crates/app/options/Cargo.toml
+++ b/crates/app/options/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "metis-app-options"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+clap = { version = "4.5.40", features = ["derive"] }
+tracing = "0.1.41"
+tendermint-rpc.workspace = true
+
+metis-primitives.workspace = true

--- a/crates/app/options/src/eth.rs
+++ b/crates/app/options/src/eth.rs
@@ -1,0 +1,28 @@
+use clap::{Args, Subcommand};
+use tendermint_rpc::Url;
+
+#[derive(Args, Debug)]
+pub struct EthArgs {
+    #[command(subcommand)]
+    pub command: EthCommands,
+}
+
+#[derive(Subcommand, Debug, Clone)]
+pub enum EthCommands {
+    /// Run the Ethereum JSON-RPC facade.
+    Run {
+        /// The URL of the Tendermint node's RPC endpoint.
+        #[arg(
+            long,
+            short,
+            default_value = "ws://127.0.0.1:26657/websocket",
+            env = "TENDERMINT_WS_URL"
+        )]
+        url: Url,
+
+        /// An optional HTTP/S proxy through which to submit requests to the
+        /// Tendermint node's RPC endpoint.
+        #[arg(long)]
+        proxy_url: Option<Url>,
+    },
+}

--- a/crates/app/options/src/genesis.rs
+++ b/crates/app/options/src/genesis.rs
@@ -1,0 +1,93 @@
+use std::path::PathBuf;
+
+use clap::{Args, Subcommand};
+use metis_primitives::U256;
+
+#[derive(Subcommand, Debug)]
+pub enum GenesisCommands {
+    /// Create a new Genesis file, with accounts and validators to be added later.
+    New(GenesisNewArgs),
+    /// Add an account to the genesis file.
+    AddAccount(GenesisAddAccountArgs),
+    /// Add a multi-sig account to the genesis file.
+    AddMultisig(GenesisAddMultisigArgs),
+    /// Add a validator to the genesis file.
+    AddValidator(GenesisAddValidatorArgs),
+    /// Convert the genesis file into the format expected by Tendermint.
+    IntoTendermint(GenesisIntoTendermintArgs),
+}
+
+#[derive(Args, Debug)]
+pub struct GenesisArgs {
+    /// Path to the genesis JSON file.
+    #[arg(long, short)]
+    pub genesis_file: PathBuf,
+
+    #[command(subcommand)]
+    pub command: GenesisCommands,
+}
+
+#[derive(Args, Debug)]
+pub struct GenesisNewArgs {
+    /// Genesis timestamp as seconds since Unix epoch.
+    #[arg(long, short)]
+    pub timestamp: u64,
+    /// Name of the network and chain.
+    #[arg(long, short = 'n')]
+    pub chain_name: String,
+    /// Network version, governs which set of built-in actors to use.
+    #[arg(long, short = 'v', default_value = "18")]
+    pub network_version: String,
+    /// Base fee for running transactions in atto.
+    #[arg(long, short = 'f')]
+    pub base_fee: U256,
+}
+
+#[derive(Args, Debug)]
+pub struct GenesisAddAccountArgs {
+    /// Path to the Secp256k1 public key exported in base64 format.
+    #[arg(long, short)]
+    pub public_key: PathBuf,
+    /// Initial balance in full FIL units.
+    #[arg(long, short)]
+    pub balance: U256,
+}
+
+#[derive(Args, Debug)]
+pub struct GenesisAddMultisigArgs {
+    /// Path to the Secp256k1 public key exported in base64 format, one for each signatory.
+    #[arg(long, short)]
+    pub public_key: Vec<PathBuf>,
+    /// Initial balance in full FIL units.
+    #[arg(long, short)]
+    pub balance: U256,
+    /// Number of signatures required.
+    #[arg(long, short)]
+    pub threshold: u64,
+    /// Linear unlock duration in block heights.
+    #[arg(long, short = 'd')]
+    pub vesting_duration: u64,
+    /// Linear unlock start block height.
+    #[arg(long, short = 's')]
+    pub vesting_start: u64,
+}
+
+#[derive(Args, Debug)]
+pub struct GenesisAddValidatorArgs {
+    /// Path to the Secp256k1 public key exported in base64 format.
+    #[arg(long, short)]
+    pub public_key: PathBuf,
+    /// Voting power.
+    #[arg(long, short = 'v')]
+    pub power: u64,
+}
+
+#[derive(Args, Debug)]
+pub struct GenesisIntoTendermintArgs {
+    /// Output file name for the Tendermint genesis JSON file.
+    #[arg(long, short)]
+    pub out: PathBuf,
+    /// Maximum block size in bytes.
+    #[arg(long, default_value_t = 22020096)]
+    pub block_max_bytes: u64,
+}

--- a/crates/app/options/src/key.rs
+++ b/crates/app/options/src/key.rs
@@ -1,0 +1,45 @@
+use clap::{Args, Subcommand};
+use std::path::PathBuf;
+
+#[derive(Subcommand, Debug)]
+pub enum KeyCommands {
+    /// Generate a new Secp256k1 key pair and export them to files in base64 format.
+    Gen(KeyGenArgs),
+    /// Convert a secret key file from base64 into the format expected by Tendermint.
+    IntoTendermint(KeyIntoTendermintArgs),
+    /// Convert a public key file from base64 into an f1 Address format an print it to STDOUT.
+    Address(KeyAddressArgs),
+}
+
+#[derive(Args, Debug)]
+pub struct KeyArgs {
+    #[command(subcommand)]
+    pub command: KeyCommands,
+}
+
+#[derive(Args, Debug)]
+pub struct KeyGenArgs {
+    /// Name used to distinguish the files from other exported keys.
+    #[arg(long, short)]
+    pub name: String,
+    /// Directory to export the key files to; it must exist.
+    #[arg(long, short, default_value = ".")]
+    pub out_dir: PathBuf,
+}
+
+#[derive(Args, Debug)]
+pub struct KeyIntoTendermintArgs {
+    /// Path to the secret key we want to convert to Tendermint format.
+    #[arg(long, short)]
+    pub secret_key: PathBuf,
+    /// Output file name for the Tendermint private validator key JSON file.
+    #[arg(long, short)]
+    pub out: PathBuf,
+}
+
+#[derive(Args, Debug)]
+pub struct KeyAddressArgs {
+    /// Path to the public key we want to convert to f1 format.
+    #[arg(long, short)]
+    pub public_key: PathBuf,
+}

--- a/crates/app/options/src/lib.rs
+++ b/crates/app/options/src/lib.rs
@@ -1,0 +1,132 @@
+use std::path::PathBuf;
+
+use clap::{Parser, Subcommand, ValueEnum};
+// use metis_utils::network::Network;
+
+use self::{eth::EthArgs, genesis::GenesisArgs, key::KeyArgs, rpc::RpcArgs, run::RunArgs};
+
+pub mod eth;
+pub mod genesis;
+pub mod key;
+pub mod rpc;
+pub mod run;
+
+/// Parse the main arguments by:
+/// 1. Parsing the [GlobalOptions]
+/// 2. Setting any system wide parameters based on the globals
+/// 3. Parsing and returning the final [Options]
+pub fn parse() -> Options {
+    // let opts: GlobalOptions = GlobalOptions::parse();
+    // fvm_shared::address::set_current_network(opts.global.network);
+    let opts: Options = Options::parse();
+    opts
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
+pub enum LogLevel {
+    Off,
+    Error,
+    Warn,
+    Info,
+    Debug,
+    Trace,
+}
+
+// #[derive(Args, Debug)]
+// pub struct GlobalArgs {
+//     /// Set the FVM Address Network. It's value affects whether `f` (main) or `t` (test) prefixed addresses are accepted.
+//     #[arg(short, long, default_value = "mainnet", env = "FM_NETWORK")]
+//     pub network: Network,
+// }
+
+/// A version of options that does partial matching on the arguments, with its only interest
+/// being the capture of global parameters that need to take effect first, before we parse [Options],
+/// because their value affects how others arse parsed.
+///
+/// This one doesn't handle `--help` or `help` so that it is passed on to the next parser,
+/// where the full set of commands and arguments can be printed properly.
+#[derive(Parser, Debug)]
+#[command(version, disable_help_flag = true)]
+pub struct GlobalOptions {
+    // #[command(flatten)]
+    // pub global: GlobalArgs,
+    /// Capture all the normal commands, basically to ingore them.
+    #[arg(allow_hyphen_values = true, trailing_var_arg = true)]
+    pub cmd: Vec<String>,
+}
+
+#[derive(Parser, Debug)]
+#[command(version)]
+pub struct Options {
+    /// Set a custom directory for data and configuration files.
+    #[arg(
+        short = 'd',
+        long,
+        default_value = "~/.fendermint",
+        env = "FM_HOME_DIR"
+    )]
+    pub home_dir: PathBuf,
+
+    /// Optionally override the default configuration.
+    #[arg(short, long, default_value = "dev")]
+    pub mode: String,
+
+    /// Set the logging level.
+    #[arg(short, long, default_value = "info", value_enum, env = "LOG_LEVEL")]
+    pub log_level: LogLevel,
+
+    // /// Global options repeated here for discoverability, so they show up in `--help` among the others.
+    // #[command(flatten)]
+    // pub global: GlobalArgs,
+    #[command(subcommand)]
+    pub command: Commands,
+}
+
+impl Options {
+    /// Tracing level, unless it's turned off.
+    pub fn tracing_level(&self) -> Option<tracing::Level> {
+        match self.log_level {
+            LogLevel::Off => None,
+            LogLevel::Error => Some(tracing::Level::ERROR),
+            LogLevel::Warn => Some(tracing::Level::WARN),
+            LogLevel::Info => Some(tracing::Level::INFO),
+            LogLevel::Debug => Some(tracing::Level::DEBUG),
+            LogLevel::Trace => Some(tracing::Level::TRACE),
+        }
+    }
+
+    pub fn config_dir(&self) -> PathBuf {
+        self.home_dir.join("config")
+    }
+}
+
+#[allow(clippy::large_enum_variant)]
+#[derive(Subcommand, Debug)]
+pub enum Commands {
+    /// Run the `App`, listening to ABCI requests from Tendermint.
+    Run(RunArgs),
+    /// Subcommands related to the construction of signing keys.
+    Key(KeyArgs),
+    /// Subcommands related to the construction of Genesis files.
+    Genesis(GenesisArgs),
+    /// Subcommands related to sending JSON-RPC commands/queries to Tendermint.
+    Rpc(RpcArgs),
+    /// Subcommands related to the Ethereum API facade.
+    Eth(EthArgs),
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::*;
+    use clap::Parser;
+
+    #[test]
+    fn ignore_help() {
+        let cmd = "fendermint --help";
+        let _opts: GlobalOptions = GlobalOptions::parse_from(cmd.split_ascii_whitespace());
+
+        // The following would print the help in tests and quit.
+        // I'm not sure what's the best way to test that this is not happening, besides eyeballing the output.
+        // let _opts: Options = Options::parse_from(cmd.split_ascii_whitespace());
+    }
+}

--- a/crates/app/options/src/rpc.rs
+++ b/crates/app/options/src/rpc.rs
@@ -1,0 +1,154 @@
+use clap::{Args, Subcommand, ValueEnum};
+use metis_primitives::{Address, Bytes, U256};
+use std::path::PathBuf;
+use tendermint_rpc::Url;
+
+#[derive(Args, Debug)]
+pub struct RpcArgs {
+    /// The URL of the Tendermint node's RPC endpoint.
+    #[arg(
+        long,
+        short,
+        default_value = "http://127.0.0.1:26657",
+        env = "TENDERMINT_RPC_URL"
+    )]
+    pub url: Url,
+
+    /// An optional HTTP/S proxy through which to submit requests to the
+    /// Tendermint node's RPC endpoint.
+    #[arg(long)]
+    pub proxy_url: Option<Url>,
+
+    #[command(subcommand)]
+    pub command: RpcCommands,
+}
+
+#[derive(Subcommand, Debug, Clone)]
+pub enum RpcCommands {
+    /// Send an ABCI query.
+    Query {
+        /// Block height to query; 0 means latest.
+        #[arg(long, short = 'b', default_value_t = 0)]
+        height: u64,
+        #[command(subcommand)]
+        command: RpcQueryCommands,
+    },
+    /// Transfer tokens between accounts.
+    Transfer {
+        /// Address of the actor to send the message to.
+        #[arg(long, short)]
+        to: Address,
+        #[command(flatten)]
+        args: TransArgs,
+    },
+    /// Subcommands related to EVM.
+    Evm {
+        #[command(subcommand)]
+        command: RpcEvmCommands,
+        #[command(flatten)]
+        args: TransArgs,
+    },
+}
+
+#[derive(Subcommand, Debug, Clone)]
+pub enum RpcQueryCommands {
+    /// Get the state of an actor; print it as JSON.
+    ActorState {
+        /// Address of the actor to query.
+        #[arg(long, short)]
+        address: Address,
+    },
+    /// Get the slowly changing state parameters.
+    StateParams,
+}
+
+#[derive(Subcommand, Debug, Clone)]
+pub enum RpcEvmCommands {
+    /// Deploy an EVM contract from source; print the results as JSON.
+    Create {
+        /// Path to a compiled Solidity contract, expected to be in hexadecimal format.
+        #[arg(long, short)]
+        contract: PathBuf,
+        /// ABI encoded constructor arguments passed to the EVM, expected to be in hexadecimal format.
+        #[arg(long, short, default_value = "")]
+        constructor_args: Bytes,
+    },
+    /// Invoke an EVM contract; print the results as JSON with the return data rendered in hexadecimal format.
+    Invoke {
+        #[command(flatten)]
+        args: EvmArgs,
+    },
+    /// Call an EVM contract without a transaction; print the results as JSON with the return data rendered in hexadecimal format.
+    Call {
+        #[command(flatten)]
+        args: EvmArgs,
+        /// Block height to query; 0 means latest.
+        #[arg(long, short = 'b', default_value_t = 0)]
+        height: u64,
+    },
+    /// Estimate the gas required to execute a FEVM invocation.
+    EstimateGas {
+        #[command(flatten)]
+        args: EvmArgs,
+        /// Block height to query; 0 means latest.
+        #[arg(long, short = 'b', default_value_t = 0)]
+        height: u64,
+    },
+}
+
+// todo call evm contract args
+/// Arguments common to FEVM method calls.
+#[derive(Args, Debug, Clone)]
+pub struct EvmArgs {
+    /// Either the actor ID based or the EAM delegated address of the contract to call.
+    #[arg(long, short)]
+    pub contract: Address,
+    // /// ABI encoded method hash, expected to be in hexadecimal format.
+    // #[arg(long, short)]
+    // pub method: Bytes,
+    // /// ABI encoded call arguments passed to the EVM, expected to be in hexadecimal format.
+    // #[arg(long, short, default_value = "")]
+    // pub method_args: Bytes,
+}
+
+/// Arguments common to transactions and transfers.
+#[derive(Args, Debug, Clone)]
+pub struct TransArgs {
+    /// Name of chain the for which the message will be signed.
+    #[arg(long, short, env = "FM_CHAIN_NAME")]
+    pub chain_name: String,
+    /// Amount of tokens to send, in full FIL, not atto.
+    #[arg(long, short, default_value = "0")]
+    pub value: U256,
+    /// Path to the secret key of the sender to sign the transaction.
+    #[arg(long, short)]
+    pub secret_key: PathBuf,
+    /// Sender account nonce.
+    #[arg(long, short = 'n')]
+    pub sequence: u64,
+    /// Maximum amount of gas that can be charged.
+    #[arg(long, default_value_t = 10_000_000_000)] // Default from ref-fvm testkit.
+    pub gas_limit: u64,
+    /// Price of gas.
+    ///
+    /// Any discrepancy between this and the base fee is paid for
+    /// by the validator who puts the transaction into the block.
+    #[arg(long, default_value = "0")]
+    pub gas_fee_cap: U256,
+    /// Gas premium.
+    #[arg(long, default_value = "0")]
+    pub gas_premium: U256,
+    /// Whether to wait for the results from Tendermint or not.
+    #[arg(long, short, default_value = "commit")]
+    pub broadcast_mode: BroadcastMode,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
+pub enum BroadcastMode {
+    /// Do no wait for the results.
+    Async,
+    /// Wait for the result of `check_tx`.
+    Sync,
+    /// Wait for the result of `deliver_tx`.
+    Commit,
+}

--- a/crates/app/options/src/run.rs
+++ b/crates/app/options/src/run.rs
@@ -1,0 +1,4 @@
+use clap::Args;
+
+#[derive(Args, Debug)]
+pub struct RunArgs;

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -1,5 +1,5 @@
 use std::path::PathBuf;
-use std::sync::{Arc, Mutex};
+// use std::sync::{Arc, Mutex};
 
 use anyhow::Result;
 use async_trait::async_trait;
@@ -7,16 +7,17 @@ use cid::Cid;
 use serde::Serialize;
 
 use metis_chain::tm_abci::abci_app::{AbciResult, Application};
-use metis_storage::{Codec, Encode, KVReadable, KVStore, KVWritable};
+// use metis_storage::{Codec, Encode, KVReadable, KVStore, KVWritable};
+use metis_storage::KVStore;
 use metis_vm::interpreter::evm::{
-    BytesMessageQuery, CheckInterpreter, GenesisInterpreter, QueryInterpreter,
+    // BytesMessageQuery, CheckInterpreter, GenesisInterpreter, QueryInterpreter,
     state::{
-        CheckStateRef,
-        exec::{EvmExecState, EvmStateParams},
-        genesis::{EvmGenesisOutput, EvmGenesisState},
-        query::EvmQueryState,
+        // CheckStateRef,
+        exec::EvmStateParams,
+        // genesis::{EvmGenesisOutput, EvmGenesisState},
+        // query::EvmQueryState,
     },
-    store::block::{Blockstore, ReadOnlyBlockstore},
+    // store::block::{Blockstore, ReadOnlyBlockstore},
 };
 use tendermint::abci::request::FinalizeBlock;
 use tendermint::abci::{request, response};
@@ -87,81 +88,80 @@ pub struct AppConfig<S: KVStore> {
 /// Handle ABCI requests.
 #[derive(Clone)]
 #[allow(dead_code, unreachable_pub)]
-pub struct App<DB, SS, S, I>
+// pub struct App<DB, SS, S, I>
+pub struct App
 where
-    SS: Blockstore + 'static,
-    S: KVStore,
+// SS: Blockstore + 'static,
+// S: KVStore,
 {
-    /// Database backing all key-value operations.
-    db: Arc<DB>,
-    /// State store, backing all the smart contracts.
-    ///
-    /// Must be kept separate from storage that can be influenced by network operations such as Bitswap;
-    /// nodes must be able to run transactions deterministically. By contrast the Bitswap store should
-    /// be able to read its own storage area as well as state storage, to serve content from both.
+    // /// Database backing all key-value operations.
+    // db: Arc<DB>,
+    // /// State store, backing all the smart contracts.
+    // ///
+    // /// Must be kept separate from storage that can be influenced by network operations such as Bitswap;
+    // /// nodes must be able to run transactions deterministically. By contrast the Bitswap store should
+    // /// be able to read its own storage area as well as state storage, to serve content from both.
     // state_store: Arc<SS>,
 
-    /// Namespace to store app state.
-    namespace: S::Namespace,
-    /// Collection of past state parameters.
-    ///
-    /// We store the state hash for the height of the block where it was committed,
-    /// which is different from how Tendermint Core will refer to it in queries,
-    /// shifted by one, because Tendermint Core will use the height where the hash
-    /// *appeared*, which is in the block *after* the one which was committed.
-    ///
-    /// The state also contains things like timestamp and the network version,
-    /// so that we can retrospectively execute EVM messages at past block heights
-    /// in read-only mode.
+    // /// Namespace to store app state.
+    // namespace: S::Namespace,
+    // /// Collection of past state parameters.
+    // ///
+    // /// We store the state hash for the height of the block where it was committed,
+    // /// which is different from how Tendermint Core will refer to it in queries,
+    // /// shifted by one, because Tendermint Core will use the height where the hash
+    // /// *appeared*, which is in the block *after* the one which was committed.
+    // ///
+    // /// The state also contains things like timestamp and the network version,
+    // /// so that we can retrospectively execute EVM messages at past block heights
+    // /// in read-only mode.
     // state_hist: KVCollection<S, BlockHeight, EvmStateParams>,
-    /// Interpreter for block lifecycle events.
-    interpreter: Arc<I>,
-    /// CID resolution pool.
+    // /// Interpreter for block lifecycle events.
+    // interpreter: Arc<I>,
+    // /// CID resolution pool.
     // resolve_pool: CheckpointPool,
-    /// The parent finality provider for top down checkpoint
+    // /// The parent finality provider for top down checkpoint
     // parent_finality_provider: Arc<ParentFinalityProvider>,
-    /// State accumulating changes during block execution.
-    exec_state: Arc<Mutex<Option<EvmExecState<SS>>>>,
-    /// Projected (partial) state accumulating during transaction checks.
-    check_state: CheckStateRef<SS>,
-    /// How much history to keep.
-    ///
-    /// Zero means unlimited.
-    state_hist_size: u64,
+    // /// State accumulating changes during block execution.
+    // exec_state: Arc<Mutex<Option<EvmExecState<SS>>>>,
+    // /// Projected (partial) state accumulating during transaction checks.
+    // check_state: CheckStateRef<SS>,
+    // /// How much history to keep.
+    // // /// Zero means unlimited.
+    // state_hist_size: u64,
 }
 
 #[allow(dead_code, unreachable_pub)]
-impl<DB, SS, S, I> App<DB, SS, S, I>
+impl App
 where
-    S: KVStore
-        + Codec<AppState>
-        + Encode<AppStoreKey>
-        + Encode<BlockHeight>
-        + Codec<EvmStateParams>,
-    DB: KVWritable<S> + KVReadable<S> + Clone + 'static,
-    SS: Blockstore + Clone + 'static,
+// S: KVStore,
+// + Codec<AppState>
+// + Encode<AppStoreKey>
+// + Encode<BlockHeight>
+// + Codec<EvmStateParams>,
+// DB: KVWritable<S> + KVReadable<S> + Clone + 'static,
+// SS: Blockstore + Clone + 'static,
 {
-    pub fn new(
-        config: AppConfig<S>,
-        db: DB,
+    pub const fn new(// config: AppConfig<S>,
+        // db: DB,
         // state_store: SS,
-        interpreter: I,
+        // interpreter: I,
         // resolve_pool: CheckpointPool,
         // parent_finality_provider: Arc<ParentFinalityProvider>,
     ) -> Result<Self> {
         let app = Self {
-            db: Arc::new(db),
+            // db: Arc::new(db),
             // state_store: Arc::new(state_store),
             // multi_engine: Arc::new(MultiEngine::new(1)),
             // builtin_actors_bundle: config.builtin_actors_bundle,
-            namespace: config.app_namespace,
+            // namespace: config.app_namespace,
             // state_hist: KVCollection::new(config.state_hist_namespace),
-            state_hist_size: config.state_hist_size,
-            interpreter: Arc::new(interpreter),
+            // state_hist_size: config.state_hist_size,
+            // interpreter: Arc::new(interpreter),
             // resolve_pool,
             // parent_finality_provider,
-            exec_state: Arc::new(Mutex::new(None)),
-            check_state: Arc::new(tokio::sync::Mutex::new(None)),
+            // exec_state: Arc::new(Mutex::new(None)),
+            // check_state: Arc::new(tokio::sync::Mutex::new(None)),
         };
         // app.init_committed_state()?;
         Ok(app)
@@ -359,42 +359,44 @@ where
 // the `tower-abci` library would throw an exception when it tried to convert a
 // `Response::Exception` into a `ConsensusResponse` for example.
 #[async_trait]
-impl<DB, SS, S, I> Application for App<DB, SS, S, I>
+// impl<DB, SS, S, I> Application for App<DB, SS, S, I>
+impl Application for App
 where
-    S: KVStore
-        + Codec<AppState>
-        + Encode<AppStoreKey>
-        + Encode<BlockHeight>
-        + Codec<EvmStateParams>,
-    S::Namespace: Sync + Send,
-    DB: KVWritable<S> + KVReadable<S> + Clone + Send + Sync + 'static,
-    SS: Blockstore + Clone + Send + Sync + 'static,
-    I: GenesisInterpreter<
-            State = EvmGenesisState<SS>,
-            Genesis = Vec<u8>,
-            Output = EvmGenesisOutput,
-        >,
-    // I: ProposalInterpreter<
-    //     State = (CheckpointPool, Arc<ParentFinalityProvider>),
-    //     Message = Vec<u8>,
-    // >,
-    // I: ExecInterpreter<
-    //     State = (
-    //         CheckpointPool,
-    //         Arc<ParentFinalityProvider>,
-    //         EvmExecState<SS>,
-    //     ),
-    //     Message = Vec<u8>,
-    //     BeginOutput = EvmApplyRet,
-    //     DeliverOutput = BytesMessageApplyRes,
-    //     EndOutput = (),
-    // >,
-    I: CheckInterpreter<
-            State = EvmExecState<ReadOnlyBlockstore<SS>>,
-            Message = Vec<u8>,
-            Output = (),
-        >,
-    I: QueryInterpreter<State = EvmQueryState<SS>, Query = BytesMessageQuery, Output = ()>,
+// S: KVStore,
+// + Codec<AppState>
+// + Encode<AppStoreKey>
+// + Encode<BlockHeight>
+// + Codec<EvmStateParams>,
+// S::Namespace: Sync + Send,
+// DB: KVWritable<S> + KVReadable<S> + Clone + Send + Sync + 'static,
+// SS: Blockstore + Clone + Send + Sync + 'static,
+// todo Implement the corresponding trait
+// I: GenesisInterpreter<
+//         State = EvmGenesisState<SS>,
+//         Genesis = Vec<u8>,
+//         Output = EvmGenesisOutput,
+//     >,
+// I: ProposalInterpreter<
+//     State = (CheckpointPool, Arc<ParentFinalityProvider>),
+//     Message = Vec<u8>,
+// >,
+// I: ExecInterpreter<
+//     State = (
+//         CheckpointPool,
+//         Arc<ParentFinalityProvider>,
+//         EvmExecState<SS>,
+//     ),
+//     Message = Vec<u8>,
+//     BeginOutput = EvmApplyRet,
+//     DeliverOutput = BytesMessageApplyRes,
+//     EndOutput = (),
+// >,
+// I: CheckInterpreter<
+//         State = EvmExecState<ReadOnlyBlockstore<SS>>,
+//         Message = Vec<u8>,
+//         Output = (),
+//     >,
+// I: QueryInterpreter<State = EvmQueryState<SS>, Query = BytesMessageQuery, Output = ()>,
 {
     /// Provide information about the ABCI application.
     async fn info(&self, _request: request::Info) -> AbciResult<response::Info> {

--- a/crates/app/src/cmd/key.rs
+++ b/crates/app/src/cmd/key.rs
@@ -1,0 +1,130 @@
+use anyhow::{Context, anyhow};
+use libsecp256k1::{PublicKey, SecretKey};
+use metis_primitives::Address;
+use rand_chacha::{ChaCha20Rng, rand_core::SeedableRng};
+use serde_json::json;
+use std::path::{Path, PathBuf};
+
+use super::{from_b64, to_b64};
+use crate::cmd;
+use metis_app_options::key::{
+    KeyAddressArgs, KeyArgs, KeyCommands, KeyGenArgs, KeyIntoTendermintArgs,
+};
+
+cmd! {
+  KeyArgs(self) {
+    match &self.command {
+        KeyCommands::Gen(args) => args.exec(()).await,
+        KeyCommands::IntoTendermint(args) => args.exec(()).await,
+        KeyCommands::Address(args) => args.exec(()).await,
+    }
+  }
+}
+
+cmd! {
+  KeyGenArgs(self) {
+    let mut rng = ChaCha20Rng::from_entropy();
+    let sk = SecretKey::random(&mut rng);
+    let pk = PublicKey::from_secret_key(&sk);
+
+    export(&self.out_dir, &self.name, "sk", &secret_to_b64(&sk))?;
+    export(&self.out_dir, &self.name, "pk", &public_to_b64(&pk))?;
+
+    Ok(())
+  }
+}
+
+cmd! {
+  KeyIntoTendermintArgs(self) {
+    let sk = read_secret_key(&self.secret_key)?;
+    let pk = PublicKey::from_secret_key(&sk);
+    let vk = tendermint::crypto::default::ecdsa_secp256k1::VerifyingKey::from_sec1_bytes(&pk.serialize())
+      .map_err(|e| anyhow!("failed to convert public key: {e}"))?;
+    let pub_key = tendermint::PublicKey::Secp256k1(vk);
+    let address = tendermint::account::Id::from(pub_key);
+
+    // tendermint-rs doesn't seem to handle Secp256k1 private keys;
+    // if it did, we could use tendermint_config::PrivateValidatorKey
+    // to encode the data structure. Tendermint should be okay with it
+    // though, as long as we match the expected keys in the JSON.
+    let priv_validator_key = json! ({
+        "address": address,
+        "pub_key": pub_key,
+        "priv_key": {
+            "type": "tendermint/PrivKeySecp256k1",
+            "value": secret_to_b64(&sk)
+        }
+    });
+    let json = serde_json::to_string_pretty(&priv_validator_key)?;
+
+    std::fs::write(&self.out, json)?;
+
+    Ok(())
+  }
+}
+
+cmd! {
+  KeyAddressArgs(self) {
+    let pk = read_public_key(&self.public_key)?;
+    let addr = Address::from_raw_public_key(&pk.serialize());
+    // let addr = Address::new_secp256k1(&pk.serialize())?;
+    println!("{}", addr);
+    Ok(())
+  }
+}
+
+#[allow(dead_code, unreachable_pub)]
+fn secret_to_b64(sk: &SecretKey) -> String {
+    to_b64(&sk.serialize())
+}
+#[allow(dead_code, unreachable_pub)]
+fn public_to_b64(pk: &PublicKey) -> String {
+    to_b64(&pk.serialize_compressed())
+}
+#[allow(dead_code, unreachable_pub)]
+fn b64_to_public(b64: &str) -> anyhow::Result<PublicKey> {
+    let json = json!(b64);
+    let pk: PublicKey = serde_json::from_value(json)?;
+    Ok(pk)
+}
+#[allow(dead_code, unreachable_pub)]
+fn b64_to_secret(b64: &str) -> anyhow::Result<SecretKey> {
+    let bz = from_b64(b64)?;
+    let sk = SecretKey::parse_slice(&bz)?;
+    Ok(sk)
+}
+#[allow(dead_code, unreachable_pub)]
+pub fn read_public_key(public_key: &PathBuf) -> anyhow::Result<PublicKey> {
+    let b64 = std::fs::read_to_string(public_key).context("failed to read public key")?;
+    let pk = b64_to_public(&b64).context("failed to parse public key")?;
+    Ok(pk)
+}
+#[allow(dead_code, unreachable_pub)]
+pub fn read_secret_key(secret_key: &PathBuf) -> anyhow::Result<SecretKey> {
+    let b64 = std::fs::read_to_string(secret_key).context("failed to read secret key")?;
+    let sk = b64_to_secret(&b64).context("failed to parse secret key")?;
+    Ok(sk)
+}
+#[allow(dead_code, unreachable_pub)]
+fn export(output_dir: &Path, name: &str, ext: &str, b64: &str) -> anyhow::Result<()> {
+    let output_path = output_dir.join(format!("{name}.{ext}"));
+    std::fs::write(output_path, b64)?;
+    Ok(())
+}
+
+// #[cfg(test)]
+// mod tests {
+//     use fendermint_vm_genesis::ValidatorKey;
+//     use quickcheck_macros::quickcheck;
+//
+//     use crate::cmd::key::b64_to_public;
+//
+//     use super::public_to_b64;
+//
+//     #[quickcheck]
+//     fn prop_public_key_deserialize_to_genesis(vk: ValidatorKey) {
+//         let b64 = public_to_b64(&vk.0);
+//         let pk = b64_to_public(&b64).unwrap();
+//         assert_eq!(pk, vk.0)
+//     }
+// }

--- a/crates/app/src/cmd/mod.rs
+++ b/crates/app/src/cmd/mod.rs
@@ -1,0 +1,105 @@
+use crate::settings::{Settings, expand_tilde};
+use anyhow::{Context, anyhow};
+use async_trait::async_trait;
+use base64::engine::GeneralPurpose;
+use base64::engine::{DecodePaddingMode, GeneralPurposeConfig};
+use base64::{Engine, alphabet};
+use metis_app_options::{Commands, Options};
+
+#[allow(dead_code, unreachable_pub)]
+pub mod key;
+#[allow(dead_code, unreachable_pub)]
+pub mod run;
+
+/// A [`GeneralPurpose`] engine using the [`alphabet::STANDARD`] base64 alphabet
+/// padding bytes when writing but requireing no padding when reading.
+const B64_ENGINE: GeneralPurpose = GeneralPurpose::new(
+    &alphabet::STANDARD,
+    GeneralPurposeConfig::new()
+        .with_encode_padding(true)
+        .with_decode_padding_mode(DecodePaddingMode::Indifferent),
+);
+
+#[allow(dead_code, unreachable_pub)]
+/// Encode bytes in a format that the Genesis deserializer can handle.
+pub fn to_b64(bz: &[u8]) -> String {
+    B64_ENGINE.encode(bz)
+}
+
+#[allow(dead_code, unreachable_pub)]
+pub fn from_b64(b64: &str) -> anyhow::Result<Vec<u8>> {
+    Ok(B64_ENGINE.decode(b64)?)
+}
+
+#[async_trait]
+#[allow(dead_code, unreachable_pub)]
+pub trait Cmd {
+    type Settings;
+    async fn exec(&self, settings: Self::Settings) -> anyhow::Result<()>;
+}
+
+/// Convenience macro to simplify declaring commands that either need or don't need settings.
+///
+/// ```text
+/// cmd! {
+///   <arg-type>(self, settings: <settings-type>) {
+///     <exec-body>
+///   }
+/// }
+/// ```
+#[macro_export]
+macro_rules! cmd {
+    // A command which needs access to some settings.
+    ($name:ident($self:ident, $settings_name:ident : $settings_type:ty) $exec:expr) => {
+        #[async_trait::async_trait]
+        impl $crate::cmd::Cmd for $name {
+            type Settings = $settings_type;
+
+            async fn exec(&$self, $settings_name: Self::Settings) -> anyhow::Result<()> {
+                $exec
+            }
+        }
+    };
+
+    // A command which works on the full `Settings`.
+    ($name:ident($self:ident, $settings:ident) $exec:expr) => {
+        cmd!($name($self, $settings: $crate::$settings::Settings) $exec);
+    };
+
+    // A command which is self-contained and doesn't need any settings.
+    ($name:ident($self:ident) $exec:expr) => {
+        cmd!($name($self, _settings: ()) $exec);
+    };
+}
+
+/// Execute the command specified in the options.
+#[allow(dead_code, unreachable_pub)]
+pub async fn exec(opts: &Options) -> anyhow::Result<()> {
+    match &opts.command {
+        Commands::Run(args) => args.exec(settings(opts)?).await,
+        Commands::Key(args) => args.exec(()).await,
+        // todo add other cmd
+        // Commands::Genesis(args) => args.exec(()).await,
+        // Commands::Rpc(args) => args.exec(()).await,
+        // Commands::Eth(args) => args.exec(settings(opts)?.eth).await,
+        _ => Ok(()),
+    }
+}
+
+/// Try to parse the settings in the configuration directory.
+fn settings(opts: &Options) -> anyhow::Result<Settings> {
+    let config_dir = match expand_tilde(opts.config_dir()) {
+        d if !d.exists() => return Err(anyhow!("'{d:?}' does not exist")),
+        d if !d.is_dir() => return Err(anyhow!("'{d:?}' is a not a directory")),
+        d => d,
+    };
+
+    tracing::info!(
+        path = config_dir.to_string_lossy().into_owned(),
+        "reading configuration"
+    );
+    let settings =
+        Settings::new(&config_dir, &opts.home_dir, &opts.mode).context("error parsing settings")?;
+
+    Ok(settings)
+}

--- a/crates/app/src/cmd/run.rs
+++ b/crates/app/src/cmd/run.rs
@@ -1,0 +1,124 @@
+use crate::{
+    app::App,
+    cmd,
+    // store::AppStore,
+    cmd::key::read_secret_key,
+    settings::Settings,
+};
+use anyhow::{Context, anyhow};
+use metis_app_options::run::RunArgs;
+use metis_chain::tm_abci::abci_app::ApplicationService;
+pub use tendermint_rpc::HttpClient;
+use tower_abci::v038::{Server, split};
+
+// use metis_vm::interpreter::{
+// evm::EvmMessageInterpreter,
+// bytes::{BytesMessageInterpreter, ProposalPrepareMode},
+// chain::{ChainMessageInterpreter, CheckpointPool},
+// signed::SignedMessageInterpreter,
+// };
+
+// use std::sync::Arc;
+// use tracing::info;
+
+cmd! {
+  RunArgs(self, settings : Settings) {
+    run(settings).await
+  }
+}
+
+/// Run the Fendermint ABCI Application.
+///
+/// This method acts as our composition root.
+async fn run(settings: Settings) -> anyhow::Result<()> {
+    let _client = HttpClient::new(settings.tendermint_rpc_url()?)
+        .context("failed to create Tendermint client")?;
+
+    let _validator_key = {
+        let sk = settings.validator_key();
+        if sk.exists() && sk.is_file() {
+            Some(read_secret_key(&sk).context("failed to read validator key")?)
+        } else {
+            tracing::debug!("validator key not configured");
+            None
+        }
+    };
+
+    // let _interpreter = EvmMessageInterpreter::<NamespaceBlockstore, _>::new(
+    //     client,
+    //     // validator_key,
+    //     // settings.contracts_dir(),
+    //     // settings.fvm.gas_overestimation_rate,
+    //     // settings.fvm.gas_search_step,
+    //     // settings.fvm.exec_in_check,
+    // );
+
+    // todo add SignedMsg/ChainMsg/BytesMsg if we need
+    // let interpreter = SignedMessageInterpreter::new(interpreter);
+    // let interpreter = ChainMessageInterpreter::new(interpreter);
+    // let interpreter =
+    //     BytesMessageInterpreter::new(interpreter, ProposalPrepareMode::AppendOnly, false);
+
+    // let ns = Namespaces::default();
+    // let _db = open_db(&settings, &ns).context("error opening DB")?;
+
+    // // Blockstore for actors.
+    // let state_store =
+    //     NamespaceBlockstore::new(db.clone(), ns.state_store).context("error creating state DB")?;
+
+    let app: App = App::new(
+        // AppConfig {
+        //     app_namespace: ns.app,
+        //     state_hist_namespace: ns.state_hist,
+        //     state_hist_size: settings.db.state_hist_size,
+        //     builtin_actors_bundle: settings.builtin_actors_bundle(),
+        // },
+        // db,
+        // state_store,
+        // interpreter,
+        // resolve_pool,
+        // parent_finality_provider.clone(),
+    )?;
+
+    let service = ApplicationService(app);
+
+    // Split it into components.
+    let (consensus, mempool, snapshot, info) = split::service(service, settings.abci.bound);
+
+    // Hand those components to the ABCI server. This is where tower layers could be added.
+    let server = Server::builder()
+        .consensus(consensus)
+        .snapshot(snapshot)
+        .mempool(mempool)
+        .info(info)
+        .finish()
+        .context("error creating ABCI server")?;
+
+    // Run the ABCI server.
+    server
+        .listen_tcp(settings.abci.listen.addr())
+        .await
+        .map_err(|e| anyhow!("error listening: {e}"))?;
+
+    Ok(())
+}
+//
+// namespaces! {
+//     Namespaces {
+//         app,
+//         state_hist,
+//         state_store,
+//         bit_store
+//     }
+// }
+//
+// /// Open database with all
+// fn open_db(settings: &Settings, ns: &Namespaces) -> anyhow::Result<RocksDb> {
+//     let path = settings.data_dir().join("rocksdb");
+//     info!(
+//         path = path.to_string_lossy().into_owned(),
+//         "opening database"
+//     );
+//     let db = RocksDb::open_cf(path, &RocksDbConfig::default(), ns.values().iter())?;
+//     Ok(db)
+// }

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -2,6 +2,9 @@
 #![allow(missing_docs)]
 
 mod app;
+mod cmd;
+mod settings;
+mod store;
 
 // Different type from `ChainEpoch` just because we might use epoch in a more traditional sense for checkpointing.
 pub type BlockHeight = u64;

--- a/crates/app/src/settings/mod.rs
+++ b/crates/app/src/settings/mod.rs
@@ -1,0 +1,217 @@
+use anyhow::Context;
+use config::{Config, ConfigError, Environment, File};
+use serde::Deserialize;
+use serde_with::{DurationSeconds, serde_as};
+use std::{
+    path::{Path, PathBuf},
+    time::Duration,
+};
+use tendermint_rpc::Url;
+
+#[allow(dead_code, unreachable_pub)]
+#[derive(Debug, Deserialize, Clone)]
+pub struct GasOpt {
+    pub min_gas_premium: u64,
+    pub num_blocks_max_prio_fee: u64,
+    pub max_fee_hist_size: u64,
+}
+
+#[allow(dead_code, unreachable_pub)]
+#[derive(Debug, Deserialize, Clone)]
+pub struct Address {
+    pub host: String,
+    pub port: u32,
+}
+
+#[allow(dead_code, unreachable_pub)]
+impl Address {
+    pub fn addr(&self) -> String {
+        format!("{}:{}", self.host, self.port)
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[allow(dead_code, unreachable_pub)]
+pub struct AbciSettings {
+    pub listen: Address,
+    /// Queue size for each ABCI component.
+    pub bound: usize,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[allow(dead_code, unreachable_pub)]
+pub struct DbSettings {
+    /// Length of the app state history to keep in the database before pruning; 0 means unlimited.
+    ///
+    /// This affects how long we can go back in state queries.
+    pub state_hist_size: u64,
+}
+
+/// Ethereum API facade settings.
+#[serde_as]
+#[derive(Debug, Deserialize, Clone)]
+#[allow(dead_code, unreachable_pub)]
+pub struct EthSettings {
+    pub listen: Address,
+    #[serde_as(as = "DurationSeconds<u64>")]
+    pub filter_timeout: Duration,
+    pub cache_capacity: usize,
+    pub gas: GasOpt,
+}
+
+#[allow(dead_code, unreachable_pub)]
+#[derive(Debug, Deserialize, Clone)]
+pub struct Settings {
+    /// Home directory configured on the CLI, to which all paths in settings can be set relative.
+    home_dir: PathBuf,
+    /// Database files.
+    data_dir: PathBuf,
+    /// Solidity contracts.
+    contracts_dir: PathBuf,
+    /// Builtin-actors CAR file.
+    builtin_actors_bundle: PathBuf,
+    /// Where to reach `CometBFT` for queries or broadcasting transactions.
+    tendermint_rpc_url: Url,
+    /// Secp256k1 private key used for signing transactions. Leave empty if not validating.
+    validator_key: PathBuf,
+    pub abci: AbciSettings,
+    pub db: DbSettings,
+    pub eth: EthSettings,
+}
+
+#[macro_export]
+macro_rules! home_relative {
+    // Using this inside something that has a `.home_dir()` function.
+    ($($name:ident),+) => {
+        $(
+        pub fn $name(&self) -> std::path::PathBuf {
+            expand_path(&self.home_dir(), &self.$name)
+        }
+        )+
+    };
+
+    // Using this outside something that requires a `home_dir` parameter to be passed to it.
+    ($settings:ty { $($name:ident),+ } ) => {
+      impl $settings {
+        $(
+        pub fn $name(&self, home_dir: &std::path::Path) -> std::path::PathBuf {
+            $crate::settings::expand_path(home_dir, &self.$name)
+        }
+        )+
+      }
+    };
+}
+
+#[allow(dead_code, unreachable_pub)]
+impl Settings {
+    home_relative!(
+        data_dir,
+        contracts_dir,
+        builtin_actors_bundle,
+        validator_key
+    );
+
+    /// Load the default configuration from a directory,
+    /// then potential overrides specific to the run mode,
+    /// then overrides from the local environment.
+    pub fn new(config_dir: &Path, home_dir: &Path, run_mode: &str) -> Result<Self, ConfigError> {
+        let c = Config::builder()
+            .add_source(File::from(config_dir.join("default")))
+            // Optional mode specific overrides, checked into git.
+            .add_source(File::from(config_dir.join(run_mode)).required(false))
+            // Optional local overrides, not checked into git.
+            .add_source(File::from(config_dir.join("local")).required(false))
+            // Add in settings from the environment (with a prefix of FM)
+            // e.g. `FM_DB__DATA_DIR=./foo/bar ./target/app` would set the database location.
+            .add_source(
+                Environment::with_prefix("fm")
+                    .prefix_separator("_")
+                    .separator("__"),
+            )
+            // Set the home directory based on what was passed to the CLI,
+            // so everything in the config can be relative to it.
+            // The `home_dir` key is not added to `default.toml` so there is no confusion
+            // about where it will be coming from.
+            .set_override("home_dir", home_dir.to_string_lossy().as_ref())?
+            .build()?;
+
+        // Deserialize (and thus freeze) the entire configuration.
+        c.try_deserialize()
+    }
+
+    /// The configured home directory.
+    pub fn home_dir(&self) -> &Path {
+        &self.home_dir
+    }
+
+    /// Tendermint RPC URL from the environment or the config file.
+    pub fn tendermint_rpc_url(&self) -> anyhow::Result<Url> {
+        // Prefer the "standard" env var used in the CLI.
+        match std::env::var("TENDERMINT_RPC_URL").ok() {
+            Some(url) => url.parse::<Url>().context("invalid Tendermint URL"),
+            None => Ok(self.tendermint_rpc_url.clone()),
+        }
+    }
+}
+
+/// Expand a path which can either be :
+/// * absolute, e.g. "/foo/bar"
+/// * relative to the system `$HOME` directory, e.g. "~/foo/bar"
+/// * relative to the configured `--home-dir` directory, e.g. "foo/bar"
+#[allow(dead_code, unreachable_pub)]
+pub fn expand_path(home_dir: &Path, path: &Path) -> PathBuf {
+    if path.starts_with("/") {
+        PathBuf::from(path)
+    } else if path.starts_with("~") {
+        expand_tilde(path)
+    } else {
+        expand_tilde(home_dir.join(path))
+    }
+}
+
+/// Expand paths that begin with "~" to `$HOME`.
+#[allow(dead_code, unreachable_pub)]
+pub fn expand_tilde<P: AsRef<Path>>(path: P) -> PathBuf {
+    let p = path.as_ref().to_path_buf();
+    if !p.starts_with("~") {
+        return p;
+    }
+    if p == Path::new("~") {
+        return dirs::home_dir().unwrap_or(p);
+    }
+    dirs::home_dir()
+        .map(|mut h| {
+            if h == Path::new("/") {
+                // `~/foo` becomes just `/foo` instead of `//foo` if `/` is home.
+                p.strip_prefix("~").unwrap().to_path_buf()
+            } else {
+                h.push(p.strip_prefix("~/").unwrap());
+                h
+            }
+        })
+        .unwrap_or(p)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::Settings;
+    use super::expand_tilde;
+
+    #[allow(dead_code)]
+    fn parse_config(run_mode: &str) -> Settings {
+        let current_dir = PathBuf::from(".");
+        let default_dir = PathBuf::from("config");
+        Settings::new(&default_dir, &current_dir, run_mode).unwrap()
+    }
+
+    #[test]
+    fn tilde_expands_to_home() {
+        let home = std::env::var("HOME").expect("should work on Linux");
+        let home_project = PathBuf::from(format!("{}/.project", home));
+        assert_eq!(expand_tilde("~/.project"), home_project);
+        assert_eq!(expand_tilde("/foo/bar"), PathBuf::from("/foo/bar"));
+        assert_eq!(expand_tilde("~foo/bar"), PathBuf::from("~foo/bar"));
+    }
+}

--- a/crates/app/src/store.rs
+++ b/crates/app/src/store.rs
@@ -1,0 +1,110 @@
+use metis_storage::{Codec, Decode, Encode, KVResult, KVStore};
+use serde::{Serialize, de::DeserializeOwned};
+use std::borrow::Cow;
+
+/// [`KVStore`] type we use to store historial data in the database.
+#[allow(dead_code, unreachable_pub)]
+#[derive(Clone)]
+pub struct AppStore;
+
+impl KVStore for AppStore {
+    type Repr = Vec<u8>;
+    type Namespace = String;
+}
+
+impl<T> Codec<T> for AppStore where Self: Encode<T> + Decode<T> {}
+
+/// CBOR serialization.
+impl<T> Encode<T> for AppStore
+where
+    T: Serialize,
+{
+    fn to_repr(_value: &T) -> KVResult<Cow<'_, Self::Repr>> {
+        todo!()
+    }
+}
+
+/// CBOR deserialization.
+impl<T> Decode<T> for AppStore
+where
+    T: DeserializeOwned,
+{
+    fn from_repr(_repr: &Self::Repr) -> KVResult<T> {
+        // fvm_ipld_encoding::from_slice(repr).map_err(|e| KVError::Codec(Box::new(e)))
+        todo!()
+    }
+}
+// todo use db store of reth
+/*
+/// A `Blockstore` and `BitswapStore` implementation we can pass to the IPLD Resolver.
+pub struct BitswapBlockstore {
+    /// The `Blockstore` implementation where we the FVM actors store their data.
+    ///
+    /// This must not be written to by Bitswap operations, because that could result
+    /// in some nodes having some data that others don't, which would lead to a
+    /// consensu failure. We can use read data from it, but not write to it.
+    state_store: NamespaceBlockstore,
+    /// The `Blockstore` implementation where Bitswap operations can write to.
+    bit_store: NamespaceBlockstore,
+}
+
+impl BitswapBlockstore {
+    pub fn new(state_store: NamespaceBlockstore, bit_store: NamespaceBlockstore) -> Self {
+        Self {
+            state_store,
+            bit_store,
+        }
+    }
+}
+
+impl Blockstore for BitswapBlockstore {
+    fn has(&self, k: &cid::Cid) -> anyhow::Result<bool> {
+        if self.bit_store.has(k)? {
+            Ok(true)
+        } else {
+            self.state_store.has(k)
+        }
+    }
+
+    fn get(&self, k: &cid::Cid) -> anyhow::Result<Option<Vec<u8>>> {
+        if let Some(data) = self.bit_store.get(k)? {
+            Ok(Some(data))
+        } else {
+            self.state_store.get(k)
+        }
+    }
+
+    fn put_keyed(&self, k: &cid::Cid, block: &[u8]) -> anyhow::Result<()> {
+        self.bit_store.put_keyed(k, block)
+    }
+
+    fn put_many_keyed<D, I>(&self, blocks: I) -> anyhow::Result<()>
+    where
+        Self: Sized,
+        D: AsRef<[u8]>,
+        I: IntoIterator<Item = (cid::Cid, D)>,
+    {
+        self.bit_store.put_many_keyed(blocks)
+    }
+}
+
+impl BitswapStore for BitswapBlockstore {
+    type Params = libipld::DefaultParams;
+
+    fn contains(&mut self, cid: &Cid) -> anyhow::Result<bool> {
+        Blockstore::has(self, cid)
+    }
+
+    fn get(&mut self, cid: &Cid) -> anyhow::Result<Option<Vec<u8>>> {
+        Blockstore::get(self, cid)
+    }
+
+    fn insert(&mut self, block: &libipld::Block<Self::Params>) -> anyhow::Result<()> {
+        Blockstore::put_keyed(self, block.cid(), block.data())
+    }
+
+    fn missing_blocks(&mut self, cid: &Cid) -> anyhow::Result<Vec<Cid>> {
+        missing_blocks::<Self, Self::Params>(self, cid)
+    }
+}
+*/


### PR DESCRIPTION
1. Add an instantiated object for the app to listen on the Tendermint ABCI port.
2. Add the necessary options and settings for starting the app via the command line.
3. Temporarily remove parameters related to store/db/state dependencies. These will be re-implemented incrementally in subsequent updates.

link to：https://github.com/MetisProtocol/metis-sdk/issues/258