### PR TITLE
feat: support rpc with cometbft client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6638,6 +6638,7 @@ dependencies = [
  "metis-chain",
  "metis-pe",
  "metis-primitives",
+ "metis-rpc",
  "metis-storage",
  "metis-vm",
  "rand_chacha 0.3.1",
@@ -6778,6 +6779,22 @@ dependencies = [
  "revm",
  "rustc-hash 2.1.1",
  "serde",
+]
+
+[[package]]
+name = "metis-rpc"
+version = "0.2.1"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bincode",
+ "metis-app-options",
+ "metis-primitives",
+ "serde",
+ "tendermint",
+ "tendermint-rpc",
+ "thiserror 2.0.12",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ metis-chain = { path = "crates/chain" }
 metis-app = { path = "crates/app" }
 metis-storage = { path = "crates/storage" }
 metis-app-options = { path = "crates/app/options" }
+metis-rpc = { path = "crates/rpc" }
 
 anyhow = "1.0.97"
 

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -28,6 +28,7 @@ metis-vm.workspace = true
 metis-pe.workspace = true
 metis-app-options.workspace = true
 metis-primitives.workspace = true
+metis-rpc.workspace = true
 
 serde_with.workspace = true
 config.workspace = true

--- a/crates/app/options/src/rpc.rs
+++ b/crates/app/options/src/rpc.rs
@@ -1,7 +1,7 @@
 use clap::{Args, Subcommand, ValueEnum};
 use metis_primitives::{Address, Bytes, U256};
 use std::path::PathBuf;
-use tendermint_rpc::Url;
+use tendermint_rpc::{Url};
 
 #[derive(Args, Debug)]
 pub struct RpcArgs {
@@ -51,16 +51,7 @@ pub enum RpcCommands {
 }
 
 #[derive(Subcommand, Debug, Clone)]
-pub enum RpcQueryCommands {
-    /// Get the state of an actor; print it as JSON.
-    ActorState {
-        /// Address of the actor to query.
-        #[arg(long, short)]
-        address: Address,
-    },
-    /// Get the slowly changing state parameters.
-    StateParams,
-}
+pub enum RpcQueryCommands {}
 
 #[derive(Subcommand, Debug, Clone)]
 pub enum RpcEvmCommands {

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -104,8 +104,6 @@ impl App {
     pub fn new(// config: AppConfig<S>,
         // db: DB,
         // state_store: SS,
-        // interpreter: I,
-        // resolve_pool: CheckpointPool,
         // parent_finality_provider: Arc<ParentFinalityProvider>,
     ) -> Result<Self> {
         let app = Self {

--- a/crates/app/src/cmd/mod.rs
+++ b/crates/app/src/cmd/mod.rs
@@ -9,6 +9,8 @@ use metis_app_options::{Commands, Options};
 #[allow(dead_code, unreachable_pub)]
 pub mod key;
 #[allow(dead_code, unreachable_pub)]
+pub mod rpc;
+#[allow(dead_code, unreachable_pub)]
 pub mod run;
 
 /// A [`GeneralPurpose`] engine using the [`alphabet::STANDARD`] base64 alphabet
@@ -80,7 +82,7 @@ pub async fn exec(opts: &Options) -> anyhow::Result<()> {
         Commands::Key(args) => args.exec(()).await,
         // todo add other cmd
         // Commands::Genesis(args) => args.exec(()).await,
-        // Commands::Rpc(args) => args.exec(()).await,
+        Commands::Rpc(args) => args.exec(()).await,
         // Commands::Eth(args) => args.exec(settings(opts)?.eth).await,
         _ => Ok(()),
     }

--- a/crates/app/src/cmd/rpc.rs
+++ b/crates/app/src/cmd/rpc.rs
@@ -1,0 +1,179 @@
+use crate::cmd;
+use crate::options::rpc::{
+    BroadcastMode, EvmArgs, RpcArgs, RpcCommands, RpcEvmCommands, RpcQueryCommands, TransArgs,
+};
+use async_trait::async_trait;
+use metis_rpc::tx::{
+    AsyncResponse, CommitResponse, GasParams, SignedMessage, SyncResponse, TxAsync, TxClient,
+    TxCommit, TxSync,
+};
+use serde::Serialize;
+use serde_json::json;
+use std::future::Future;
+use std::pin::Pin;
+use tendermint::abci::types::ExecTxResult;
+use tendermint::block::Height;
+use tendermint_rpc::HttpClient;
+
+use metis_primitives::{Address, U256};
+use metis_rpc::client::ClientApi;
+
+cmd! {
+  RpcArgs(self) {
+    let client = ClientApi::new_http(self.url.clone(), self.proxy_url.clone())?;
+    match self.command.clone() {
+      RpcCommands::Query { height, command } => {
+        let height = Height::try_from(height)?;
+        query(client, height, command).await
+      },
+      RpcCommands::Transfer { args, to } => {
+        transfer(client, args, to).await
+      },
+      RpcCommands::Evm { args:_, command } => match command {
+        RpcEvmCommands::Create { contract:_, constructor_args:_ } => {
+            // evm_create(client, args, contract, constructor_args).await
+            todo!()
+        }
+        RpcEvmCommands::Invoke { args: EvmArgs { contract:_ }} => {
+            // evm_invoke(client, args, contract, method, method_args).await
+            todo!()
+        }
+        RpcEvmCommands::Call { args: EvmArgs { contract:_ }, height} => {
+            let _height = Height::try_from(height)?;
+            // evm_call(client, args, contract, method, method_args, height).await
+            todo!()
+        }
+        RpcEvmCommands::EstimateGas { args: EvmArgs { contract:_ }, height} => {
+            let _height = Height::try_from(height)?;
+            // evm_estimate_gas(client, args, contract, method, method_args, height).await
+            todo!()
+        }
+      }
+    }
+  }
+}
+
+// todo put query api into query.rs
+// should include all the interface of tendermint-rpc::client::Client
+// The implementation of the interface is in rpc/src/client_api.rs
+/// Run an ABCI query and print the results on STDOUT.
+async fn query(
+    _client: ClientApi,
+    _height: Height,
+    _command: RpcQueryCommands,
+) -> anyhow::Result<()> {
+    Ok(())
+}
+
+/// Create a client, make a call to Tendermint with a closure, then maybe extract some JSON
+/// depending on the return value, finally print the result in JSON.
+async fn broadcast_and_print<F, T, G>(
+    client: ClientApi,
+    args: TransArgs,
+    f: F,
+    g: G,
+) -> anyhow::Result<()>
+where
+    F: FnOnce(
+        ClientApi,
+        U256,
+        GasParams,
+    ) -> Pin<Box<dyn Future<Output = anyhow::Result<BroadcastResponse<T>>> + Send>>,
+    G: FnOnce(T) -> serde_json::Value,
+    T: Sync + Send,
+{
+    let gas_params = gas_params(&args);
+    let res = f(client, args.value, gas_params).await?;
+    let json = match res {
+        BroadcastResponse::Async(res) => json!({"response": res.response}),
+        BroadcastResponse::Sync(res) => json!({"response": res.response}),
+        BroadcastResponse::Commit(res) => {
+            let return_data = res.return_data.map(g).unwrap_or(serde_json::Value::Null);
+            json!({"response": res.response, "return_data": return_data})
+        }
+    };
+    print_json(&json)
+}
+
+/// Execute token transfer through RPC and print the response to STDOUT as JSON.
+async fn transfer(client: ClientApi, args: TransArgs, to: Address) -> anyhow::Result<()> {
+    broadcast_and_print(
+        client,
+        args.clone(),
+        |client, value, gas_params| {
+            let mut client = TransClient::new(client, &args).unwrap();
+            Box::pin(async move { client.transfer(to, value, gas_params).await })
+        },
+        |_| serde_json::Value::Null,
+    )
+    .await
+}
+
+/// Print out pretty-printed JSON.
+///
+/// People can use `jq` to turn it into compact form if they want to save the results to a `.jsonline`
+/// file, but the default of having human readable output seems more useful.
+fn print_json<T: Serialize>(value: &T) -> anyhow::Result<()> {
+    let json = serde_json::to_string_pretty(&value)?;
+    println!("{}", json);
+    Ok(())
+}
+
+pub enum BroadcastResponse<T> {
+    Async(AsyncResponse<T>),
+    Sync(SyncResponse<T>),
+    Commit(CommitResponse<T>),
+}
+
+struct BroadcastModeWrapper(BroadcastMode);
+
+impl metis_rpc::tx::BroadcastMode for BroadcastModeWrapper {
+    type Response<T> = BroadcastResponse<T>;
+}
+
+fn gas_params(args: &TransArgs) -> GasParams {
+    GasParams {
+        gas_limit: args.gas_limit,
+        gas_fee_cap: args.gas_fee_cap.clone(),
+        gas_premium: args.gas_premium.clone(),
+    }
+}
+
+struct TransClient {
+    inner: ClientApi<HttpClient>,
+    broadcast_mode: BroadcastMode,
+}
+
+impl TransClient {
+    pub fn new(client: ClientApi, args: &TransArgs) -> anyhow::Result<Self> {
+        let client = Self {
+            inner: client,
+            broadcast_mode: args.broadcast_mode,
+        };
+        Ok(client)
+    }
+}
+
+#[async_trait]
+impl TxClient<BroadcastModeWrapper> for TransClient {
+    async fn perform<F, T>(&self, msg: SignedMessage, f: F) -> anyhow::Result<BroadcastResponse<T>>
+    where
+        F: FnOnce(&ExecTxResult) -> anyhow::Result<T> + Sync + Send,
+        T: Sync + Send,
+    {
+        match self.broadcast_mode {
+            BroadcastMode::Async => {
+                let res = TxClient::<TxAsync>::perform(&self.inner, msg, f).await?;
+                Ok(BroadcastResponse::Async(res))
+            }
+            BroadcastMode::Sync => {
+                let res = TxClient::<TxSync>::perform(&self.inner, msg, f).await?;
+                Ok(BroadcastResponse::Sync(res))
+            }
+            BroadcastMode::Commit => {
+                let res = TxClient::<TxCommit>::perform(&self.inner, msg, f).await?;
+                Ok(BroadcastResponse::Commit(res))
+            }
+        }
+    }
+}

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "metis-rpc"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+exclude.workspace = true
+license.workspace = true
+readme.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+async-trait.workspace = true
+tracing.workspace = true
+thiserror.workspace = true
+serde.workspace = true
+bincode.workspace = true
+
+tendermint.workspace = true
+tendermint-rpc.workspace = true
+
+metis-primitives.workspace = true
+metis-app-options.workspace = true
+
+[features]
+async-send = []
+
+[lints]
+workspace = true

--- a/crates/rpc/src/client.rs
+++ b/crates/rpc/src/client.rs
@@ -1,0 +1,156 @@
+use std::marker::PhantomData;
+
+use anyhow::{Context, anyhow};
+use async_trait::async_trait;
+use tendermint::abci::types::ExecTxResult;
+use tendermint_rpc::{Client, HttpClient, Scheme, Url};
+use tendermint_rpc::{WebSocketClient, WebSocketClientDriver};
+
+use crate::tx::{
+    AsyncResponse, CommitResponse, SignedMessage, SyncResponse, TxAsync, TxClient, TxCommit, TxSync,
+};
+
+// Retrieve the proxy URL with precedence:
+// 1. If supplied, that's the proxy URL used.
+// 2. If not supplied, but environment variable HTTP_PROXY or HTTPS_PROXY are
+//    supplied, then use the appropriate variable for the URL in question.
+//
+// Copied from `tendermint_rpc`.
+fn get_http_proxy_url(url_scheme: Scheme, proxy_url: Option<Url>) -> anyhow::Result<Option<Url>> {
+    match proxy_url {
+        Some(u) => Ok(Some(u)),
+        None => match url_scheme {
+            Scheme::Http => std::env::var("HTTP_PROXY").ok(),
+            Scheme::Https => std::env::var("HTTPS_PROXY")
+                .ok()
+                .or_else(|| std::env::var("HTTP_PROXY").ok()),
+            _ => {
+                if std::env::var("HTTP_PROXY").is_ok() || std::env::var("HTTPS_PROXY").is_ok() {
+                    tracing::warn!(
+                        "Ignoring HTTP proxy environment variables for non-HTTP client connection"
+                    );
+                }
+                None
+            }
+        }
+        .map(|u| u.parse::<Url>().map_err(|e| anyhow!(e)))
+        .transpose(),
+    }
+}
+
+/// Create a Tendermint HTTP client.
+pub fn http_client(url: Url, proxy_url: Option<Url>) -> anyhow::Result<HttpClient> {
+    let proxy_url = get_http_proxy_url(url.scheme(), proxy_url)?;
+    let client = match proxy_url {
+        Some(proxy_url) => {
+            tracing::debug!(
+                "Using HTTP client with proxy {} to submit request to {}",
+                proxy_url,
+                url
+            );
+            HttpClient::new_with_proxy(url, proxy_url)?
+        }
+        None => {
+            tracing::debug!("Using HTTP client to submit request to: {}", url);
+            HttpClient::new(url)?
+        }
+    };
+    Ok(client)
+}
+
+/// Create a Tendermint WebSocket client.
+///
+/// The caller must start the driver in a background task.
+pub async fn ws_client(url: Url) -> anyhow::Result<(WebSocketClient, WebSocketClientDriver)> {
+    // TODO: Doesn't handle proxy.
+    tracing::debug!("Using WS client to submit request to: {}", url);
+    let (client, driver) = WebSocketClient::new(url).await?;
+    Ok((client, driver))
+}
+
+/// Unauthenticated Tendermint client.
+#[derive(Clone, Debug)]
+pub struct ClientApi<C = HttpClient> {
+    inner: C,
+}
+
+impl ClientApi<HttpClient> {
+    /// new client with http
+    pub fn new_http(url: Url, proxy_url: Option<Url>) -> anyhow::Result<Self> {
+        let inner = http_client(url, proxy_url)?;
+        Ok(Self { inner })
+    }
+}
+
+#[async_trait]
+impl<C> TxClient<TxAsync> for ClientApi<C>
+where
+    C: Client + Sync + Send,
+{
+    async fn perform<F, T>(&self, msg: SignedMessage, _f: F) -> anyhow::Result<AsyncResponse<T>>
+    where
+        F: FnOnce(&ExecTxResult) -> anyhow::Result<T> + Sync + Send,
+    {
+        let data = msg.serialize()?;
+        let response = self.inner.broadcast_tx_async(data).await?;
+        let response = AsyncResponse {
+            response,
+            return_data: PhantomData,
+        };
+        Ok(response)
+    }
+}
+
+#[async_trait]
+impl<C> TxClient<TxSync> for ClientApi<C>
+where
+    C: Client + Sync + Send,
+{
+    async fn perform<F, T>(
+        &self,
+        msg: SignedMessage,
+        _f: F,
+    ) -> anyhow::Result<crate::tx::SyncResponse<T>>
+    where
+        F: FnOnce(&ExecTxResult) -> anyhow::Result<T> + Sync + Send,
+    {
+        let data = msg.serialize()?;
+        let response = self.inner.broadcast_tx_sync(data).await?;
+        let response = SyncResponse {
+            response,
+            return_data: PhantomData,
+        };
+        Ok(response)
+    }
+}
+
+#[async_trait]
+impl<C> TxClient<TxCommit> for ClientApi<C>
+where
+    C: Client + Sync + Send,
+{
+    async fn perform<F, T>(
+        &self,
+        msg: SignedMessage,
+        f: F,
+    ) -> anyhow::Result<crate::tx::CommitResponse<T>>
+    where
+        F: FnOnce(&ExecTxResult) -> anyhow::Result<T> + Sync + Send,
+    {
+        let data = msg.serialize()?;
+        let response = self.inner.broadcast_tx_commit(data).await?;
+        // We have a fully `DeliverTx` with default fields even if `CheckTx` indicates failure.
+        let return_data = if response.check_tx.code.is_err() || response.tx_result.code.is_err() {
+            None
+        } else {
+            let return_data =
+                f(&response.tx_result).context("error decoding data from deliver_tx in commit")?;
+            Some(return_data)
+        };
+        let response = CommitResponse {
+            response,
+            return_data,
+        };
+        Ok(response)
+    }
+}

--- a/crates/rpc/src/client_api.rs
+++ b/crates/rpc/src/client_api.rs
@@ -1,0 +1,294 @@
+use std::fmt::{Debug, Display};
+use tendermint::{abci::Code, abci::response::Info, block::Height, merkle::proof::ProofOps};
+use tendermint_rpc::endpoint::{
+    abci_info, block, block_results, blockchain, commit, consensus_params, consensus_state, health,
+    net_info, status,
+};
+use tendermint_rpc::{Error as RpcError, Order, query::Query};
+use thiserror::Error;
+
+const HEIGHT_CAST_ERR: &str = "Failed to cast block height";
+
+#[allow(missing_docs)]
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("{0}")]
+    Tendermint(#[from] tendermint_rpc::Error),
+    #[error("Decoding error: {0}")]
+    Decoding(#[from] std::io::Error),
+    #[error("Info log: {0}, error code: {1}")]
+    Query(String, u32),
+    #[error("Invalid block height: {0} (overflown i64)")]
+    InvalidHeight(u64),
+}
+
+/// Generic response from a query
+#[derive(Clone, Debug, Default)]
+pub struct ResponseQuery<T> {
+    /// Response data to be borsh encoded
+    pub data: T,
+    /// Non-deterministic log of the request execution
+    pub info: String,
+    /// Optional proof - used for storage value reads which request `prove`
+    pub proof: Option<ProofOps>,
+    /// Block height from which data was derived
+    pub height: u64,
+}
+
+/// [`ResponseQuery`] with borsh-encoded `data` field
+pub type EncodedResponseQuery = ResponseQuery<Vec<u8>>;
+
+/// A client with async request dispatcher method, which can be used to invoke
+/// type-safe methods from a root queries `Router`, generated
+/// via `router!` macro.
+#[cfg_attr(feature = "async-send", async_trait::async_trait)]
+#[cfg_attr(not(feature = "async-send"), async_trait::async_trait(?Send))]
+pub trait Client {
+    /// `std::io::Error` can happen in decoding with
+    /// `BorshDeserialize::try_from_slice`
+    type Error: From<std::io::Error> + Display + Debug;
+
+    /// Send a simple query request at the given path. For more options, use the
+    /// `request` method.
+    async fn simple_request(&self, path: String) -> Result<Vec<u8>, Self::Error> {
+        self.request(path, None, None, false)
+            .await
+            .map(|response| response.data)
+    }
+
+    /// Send a query request at the given path.
+    async fn request(
+        &self,
+        path: String,
+        data: Option<Vec<u8>>,
+        height: Option<u64>,
+        prove: bool,
+    ) -> Result<EncodedResponseQuery, Self::Error>;
+
+    /// `/abci_info`: get information about the ABCI application.
+    async fn abci_info(&self) -> Result<Info, RpcError> {
+        Ok(self.perform(abci_info::Request).await?.response)
+    }
+
+    /// `/broadcast_tx_sync`: broadcast a transaction, returning the response
+    /// from `CheckTx`.
+    async fn broadcast_tx_sync(
+        &self,
+        tx: impl Into<Vec<u8>>,
+    ) -> Result<tendermint_rpc::endpoint::broadcast::tx_sync::Response, RpcError> {
+        self.perform(tendermint_rpc::endpoint::broadcast::tx_sync::Request::new(
+            tx,
+        ))
+        .await
+    }
+
+    /// `/block`: get the latest block.
+    async fn latest_block(&self) -> Result<block::Response, RpcError> {
+        self.perform(block::Request::default()).await
+    }
+
+    /// `/block`: get block at a given height.
+    async fn block<H>(&self, height: H) -> Result<block::Response, RpcError>
+    where
+        H: TryInto<Height> + Send,
+    {
+        self.perform(block::Request::new(
+            height
+                .try_into()
+                .map_err(|_| RpcError::parse(HEIGHT_CAST_ERR.to_string()))?,
+        ))
+        .await
+    }
+
+    /// `/block_search`: search for blocks by BeginBlock and EndBlock events.
+    async fn block_search(
+        &self,
+        query: Query,
+        page: u32,
+        per_page: u8,
+        order: Order,
+    ) -> Result<tendermint_rpc::endpoint::block_search::Response, RpcError> {
+        self.perform(tendermint_rpc::endpoint::block_search::Request::new(
+            query, page, per_page, order,
+        ))
+        .await
+    }
+
+    /// `/block_results`: get ABCI results for a block at a particular height.
+    async fn block_results<H>(
+        &self,
+        height: H,
+    ) -> Result<tendermint_rpc::endpoint::block_results::Response, RpcError>
+    where
+        H: TryInto<Height> + Send,
+    {
+        self.perform(tendermint_rpc::endpoint::block_results::Request::new(
+            height
+                .try_into()
+                .map_err(|_| RpcError::parse(HEIGHT_CAST_ERR.to_string()))?,
+        ))
+        .await
+    }
+
+    /// `/tx_search`: search for transactions with their results.
+    async fn tx_search(
+        &self,
+        query: Query,
+        prove: bool,
+        page: u32,
+        per_page: u8,
+        order: Order,
+    ) -> Result<tendermint_rpc::endpoint::tx_search::Response, RpcError> {
+        self.perform(tendermint_rpc::endpoint::tx_search::Request::new(
+            query, prove, page, per_page, order,
+        ))
+        .await
+    }
+
+    /// `/abci_query`: query the ABCI application
+    async fn abci_query<V>(
+        &self,
+        path: Option<String>,
+        data: V,
+        height: Option<Height>,
+        prove: bool,
+    ) -> Result<tendermint_rpc::endpoint::abci_query::AbciQuery, RpcError>
+    where
+        V: Into<Vec<u8>> + Send,
+    {
+        Ok(self
+            .perform(tendermint_rpc::endpoint::abci_query::Request::new(
+                path, data, height, prove,
+            ))
+            .await?
+            .response)
+    }
+
+    /// `/block_results`: get ABCI results for the latest block.
+    async fn latest_block_results(&self) -> Result<block_results::Response, RpcError> {
+        self.perform(block_results::Request::default()).await
+    }
+
+    /// `/blockchain`: get block headers for `min` <= `height` <= `max`.
+    ///
+    /// Block headers are returned in descending order (highest first).
+    ///
+    /// Returns at most 20 items.
+    async fn blockchain<H>(&self, min: H, max: H) -> Result<blockchain::Response, RpcError>
+    where
+        H: TryInto<Height> + Send,
+    {
+        self.perform(blockchain::Request::new(
+            min.try_into()
+                .map_err(|_| RpcError::parse(HEIGHT_CAST_ERR.to_string()))?,
+            max.try_into()
+                .map_err(|_| RpcError::parse(HEIGHT_CAST_ERR.to_string()))?,
+        ))
+        .await
+    }
+
+    /// `/commit`: get block commit at a given height.
+    async fn commit<H>(&self, height: H) -> Result<commit::Response, RpcError>
+    where
+        H: TryInto<Height> + Send,
+    {
+        self.perform(commit::Request::new(
+            height
+                .try_into()
+                .map_err(|_| RpcError::parse(HEIGHT_CAST_ERR.to_string()))?,
+        ))
+        .await
+    }
+
+    /// `/consensus_params`: get current consensus parameters at the specified
+    /// height.
+    async fn consensus_params<H>(&self, height: H) -> Result<consensus_params::Response, RpcError>
+    where
+        H: TryInto<Height> + Send,
+    {
+        self.perform(consensus_params::Request::new(Some(
+            height
+                .try_into()
+                .map_err(|_| RpcError::parse(HEIGHT_CAST_ERR.to_string()))?,
+        )))
+        .await
+    }
+
+    /// `/consensus_state`: get current consensus state
+    async fn consensus_state(&self) -> Result<consensus_state::Response, RpcError> {
+        self.perform(consensus_state::Request::new()).await
+    }
+
+    /// `/consensus_params`: get the latest consensus parameters.
+    async fn latest_consensus_params(&self) -> Result<consensus_params::Response, RpcError> {
+        self.perform(consensus_params::Request::new(None)).await
+    }
+
+    /// `/commit`: get the latest block commit
+    async fn latest_commit(&self) -> Result<commit::Response, RpcError> {
+        self.perform(commit::Request::default()).await
+    }
+
+    /// `/health`: get node health.
+    ///
+    /// Returns empty result (200 OK) on success, no response in case of an
+    /// error.
+    async fn health(&self) -> Result<(), RpcError> {
+        self.perform(health::Request).await?;
+        Ok(())
+    }
+
+    /// `/net_info`: obtain information about P2P and other network connections.
+    async fn net_info(&self) -> Result<net_info::Response, RpcError> {
+        self.perform(net_info::Request).await
+    }
+
+    /// `/status`: get Tendermint status including node info, pubkey, latest
+    /// block hash, app hash, block height and time.
+    async fn status(&self) -> Result<status::Response, RpcError> {
+        self.perform(status::Request).await
+    }
+
+    /// Perform a request against the RPC endpoint
+    async fn perform<R>(&self, request: R) -> Result<R::Output, RpcError>
+    where
+        R: tendermint_rpc::SimpleRequest;
+}
+
+#[cfg_attr(feature = "async-send", async_trait::async_trait)]
+#[cfg_attr(not(feature = "async-send"), async_trait::async_trait(?Send))]
+impl<C: tendermint_rpc::client::Client + Sync> Client for C {
+    type Error = Error;
+
+    async fn request(
+        &self,
+        path: String,
+        data: Option<Vec<u8>>,
+        height: Option<u64>,
+        prove: bool,
+    ) -> Result<EncodedResponseQuery, Self::Error> {
+        let data = data.unwrap_or_default();
+        let zero: u8 = 0;
+        let height = height
+            .map(|height| Height::try_from(zero).map_err(|_err| Error::InvalidHeight(height)))
+            .transpose()?;
+
+        let response = self.abci_query(Some(path), data, height, prove).await?;
+        match response.code {
+            Code::Ok => Ok(EncodedResponseQuery {
+                data: response.value,
+                info: response.info,
+                proof: response.proof,
+                height: response.height.value().into(),
+            }),
+            Code::Err(code) => Err(Error::Query(response.info, code.into())),
+        }
+    }
+
+    async fn perform<R>(&self, request: R) -> Result<R::Output, RpcError>
+    where
+        R: tendermint_rpc::SimpleRequest,
+    {
+        tendermint_rpc::client::Client::perform(self, request).await
+    }
+}

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -1,0 +1,10 @@
+//! rpc
+
+/// client for rpc
+pub mod client;
+
+/// not use now, for tendermint client api
+pub mod client_api;
+
+/// tx client
+pub mod tx;

--- a/crates/rpc/src/tx.rs
+++ b/crates/rpc/src/tx.rs
@@ -1,0 +1,121 @@
+use async_trait::async_trait;
+use bincode::serialize;
+use serde::{Deserialize, Serialize};
+use std::marker::PhantomData;
+
+use metis_primitives::{Address, TxEnv, U256};
+use tendermint::abci::types::ExecTxResult;
+use tendermint_rpc::endpoint::broadcast::{tx_async, tx_commit, tx_sync};
+
+#[derive(Clone, Debug)]
+/// gas params
+pub struct GasParams {
+    /// Maximum amount of gas that can be charged.
+    pub gas_limit: u64,
+    /// Price of gas.
+    ///
+    /// Any discrepancy between this and the base fee is paid for
+    /// by the validator who puts the transaction into the block.
+    pub gas_fee_cap: U256,
+    /// Gas premium.
+    pub gas_premium: U256,
+}
+
+#[allow(missing_docs)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SignedMessage {
+    tx: TxEnv,
+    signature: Vec<u8>,
+}
+
+impl SignedMessage {
+    /// serialize for SignedMessage
+    pub fn serialize(&self) -> anyhow::Result<Vec<u8>> {
+        Ok(serialize(&self)?)
+    }
+}
+
+/// Abstracting away what the return value is based on whether
+/// we broadcast transactions in sync, async or commit mode.
+pub trait BroadcastMode {
+    /// Response wrapper
+    type Response<T>;
+}
+
+/// client for submitting transactions.
+#[async_trait]
+pub trait TxClient<M: BroadcastMode = TxCommit>: Send + Sync {
+    /// Transfer tokens to another account.
+    async fn transfer(
+        &mut self,
+        _to: Address,
+        _value: U256,
+        _gas_params: GasParams,
+    ) -> anyhow::Result<M::Response<()>> {
+        // todo make SignedMsg
+        // let tx = MakeTx(from, to, amount)
+        // let sig = Sign(tx)
+        // let msg = SignedMessage{tx, sig}
+        let msg = SignedMessage {
+            tx: Default::default(),
+            signature: vec![],
+        };
+        let fut = self.perform(msg, |_| Ok(()));
+        let res = fut.await?;
+        Ok(res)
+    }
+
+    #[allow(missing_docs)]
+    async fn perform<F, T>(&self, msg: SignedMessage, f: F) -> anyhow::Result<M::Response<T>>
+    where
+        F: FnOnce(&ExecTxResult) -> anyhow::Result<T> + Sync + Send,
+        T: Sync + Send;
+}
+/// Return immediately after the transaction is broadcasted without waiting for check results.
+#[derive(Debug)]
+pub struct TxAsync;
+/// Wait for the check results before returning from broadcast.
+#[derive(Debug)]
+pub struct TxSync;
+/// Wait for the delivery results before returning from broadcast.
+#[derive(Debug)]
+pub struct TxCommit;
+
+#[derive(Debug)]
+/// Response from Tendermint
+pub struct AsyncResponse<T> {
+    /// Response from Tendermint.
+    pub response: tx_async::Response,
+    /// Parsed return data, if the response indicates success.
+    pub return_data: PhantomData<T>,
+}
+
+#[derive(Debug)]
+/// Response from Tendermint
+pub struct SyncResponse<T> {
+    /// Response from Tendermint.
+    pub response: tx_sync::Response,
+    /// Parsed return data, if the response indicates success.
+    pub return_data: PhantomData<T>,
+}
+
+#[derive(Debug)]
+/// Response from Tendermint
+pub struct CommitResponse<T> {
+    /// Response from Tendermint.
+    pub response: tx_commit::Response,
+    /// Parsed return data, if the response indicates success.
+    pub return_data: Option<T>,
+}
+
+impl BroadcastMode for TxAsync {
+    type Response<T> = AsyncResponse<T>;
+}
+
+impl BroadcastMode for TxSync {
+    type Response<T> = SyncResponse<T>;
+}
+
+impl BroadcastMode for TxCommit {
+    type Response<T> = CommitResponse<T>;
+}


### PR DESCRIPTION
Support RPC methods for tx sending, status querying, etc. 
Interface definitions are complete, with some logic pending implementation.

closes: https://github.com/MetisProtocol/metis-sdk/issues/255
closes: https://github.com/MetisProtocol/metis-sdk/issues/247