### PR TITLE
chore: bump version to 0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -198,7 +198,7 @@ dirs = "*"
 tracing-subscriber = "*"
 
 [workspace.package]
-version = "0.2.1"
+version = "0.3.0"
 edition = "2024"
 rust-version = "1.87"
 exclude = [".github/"]


### PR DESCRIPTION
chore: bump version to 0.3.0